### PR TITLE
Add pppd option "stop-bits" to set number of serial port stop bits.

### DIFF
--- a/pppd/pppd.h
+++ b/pppd/pppd.h
@@ -279,6 +279,7 @@ extern int	kdebugflag;	/* Tell kernel to print debug messages */
 extern int	default_device;	/* Using /dev/tty or equivalent */
 extern char	devnam[MAXPATHLEN];	/* Device name */
 extern int	crtscts;	/* Use hardware flow control */
+extern int	stop_bits;	/* Number of serial port stop bits */
 extern bool	modem;		/* Use modem control lines */
 extern int	inspeed;	/* Input/Output speed requested */
 extern u_int32_t netmask;	/* IP netmask to set on interface */

--- a/pppd/sys-linux.c
+++ b/pppd/sys-linux.c
@@ -966,6 +966,9 @@ void set_up_tty(int tty_fd, int local)
 	break;
     }
 
+    if (stop_bits >= 2)
+	tios.c_cflag |= CSTOPB;
+
     speed = translate_speed(inspeed);
     if (speed) {
 	cfsetospeed (&tios, speed);

--- a/pppd/sys-solaris.c
+++ b/pppd/sys-solaris.c
@@ -1225,6 +1225,9 @@ set_up_tty(fd, local)
     }
 #endif
 
+    if (stop_bits >= 2)
+	tios.c_cflag |= CSTOPB;
+
     tios.c_cflag |= CS8 | CREAD | HUPCL;
     if (local || !modem)
 	tios.c_cflag |= CLOCAL;

--- a/pppd/tty.c
+++ b/pppd/tty.c
@@ -136,6 +136,7 @@ struct stat devstat;		/* result of stat() on devnam */
 
 /* option variables */
 int	crtscts = 0;		/* Use hardware flow control */
+int	stop_bits = 1;		/* Number of serial port stop bits */
 bool	modem = 1;		/* Use modem control lines */
 int	inspeed = 0;		/* Input/Output speed requested */
 bool	lockflag = 0;		/* Create lock file to lock the serial dev */
@@ -221,6 +222,9 @@ option_t tty_options[] = {
       OPT_PRIOSUB | OPT_ALIAS | OPT_NOARG | OPT_VAL(-1) },
     { "xonxoff", o_special_noarg, (void *)setxonxoff,
       "Set software (XON/XOFF) flow control", OPT_PRIOSUB },
+    { "stop-bits", o_int, &stop_bits,
+      "Number of stop bits in serial port",
+      OPT_PRIO | OPT_PRIVFIX | OPT_LIMITS, NULL, 2, 1 },
 
     { "modem", o_bool, &modem,
       "Use modem control lines", OPT_PRIO | 1 },


### PR DESCRIPTION
This allows for configuring the serial device for 2 stop bits (default is 1 stop bit).
