### PR TITLE
linux: support non-standard baudrates

### DIFF
--- a/pppd/Makefile.linux
+++ b/pppd/Makefile.linux
@@ -13,7 +13,8 @@ TARGETS = pppd
 
 PPPDSRCS = main.c magic.c fsm.c lcp.c ipcp.c upap.c chap-new.c md5.c ccp.c \
 	   ecp.c ipxcp.c auth.c options.c sys-linux.c md4.c chap_ms.c \
-	   demand.c utils.c tty.c eap.c chap-md5.c session.c
+	   demand.c utils.c tty.c eap.c chap-md5.c session.c \
+	   sys-linux-termios2.c
 
 HEADERS = ccp.h session.h chap-new.h ecp.h fsm.h ipcp.h \
 	ipxcp.h lcp.h magic.h md5.h patchlevel.h pathnames.h pppd.h \
@@ -22,7 +23,7 @@ HEADERS = ccp.h session.h chap-new.h ecp.h fsm.h ipcp.h \
 MANPAGES = pppd.8
 PPPDOBJS = main.o magic.o fsm.o lcp.o ipcp.o upap.o chap-new.o md5.o ccp.o \
 	   ecp.o auth.o options.o demand.o utils.o sys-linux.o ipxcp.o tty.o \
-	   eap.o chap-md5.o session.o
+	   eap.o chap-md5.o session.o sys-linux-termios2.o
 
 #
 # include dependencies if present

--- a/pppd/sys-linux-termios2.c
+++ b/pppd/sys-linux-termios2.c
@@ -1,0 +1,85 @@
+/*
+ * sys-linux-termios2.c - linux termios2 specific file
+ * We can't be in sys-linux.c to avoid conflict with termios.h
+ *
+ * Copyright (c) 1994-2004 Paul Mackerras. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. The name(s) of the authors of this software must not be used to
+ *    endorse or promote products derived from this software without
+ *    prior written permission.
+ *
+ * 3. Redistributions of any form whatsoever must retain the following
+ *    acknowledgment:
+ *    "This product includes software developed by Paul Mackerras
+ *     <paulus@samba.org>".
+ *
+ * THE AUTHORS OF THIS SOFTWARE DISCLAIM ALL WARRANTIES WITH REGARD TO
+ * THIS SOFTWARE, INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS, IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY
+ * SPECIAL, INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN
+ * AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING
+ * OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *
+ * Derived from main.c and pppd.h, which are:
+ *
+ * Copyright (c) 1984-2000 Carnegie Mellon University. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *
+ * 3. The name "Carnegie Mellon University" must not be used to
+ *    endorse or promote products derived from this software without
+ *    prior written permission. For permission or any legal
+ *    details, please contact
+ *      Office of Technology Transfer
+ *      Carnegie Mellon University
+ *      5000 Forbes Avenue
+ *      Pittsburgh, PA  15213-3890
+ *      (412) 268-4387, fax: (412) 268-7395
+ *      tech-transfer@andrew.cmu.edu
+ *
+ * 4. Redistributions of any form whatsoever must retain the following
+ *    acknowledgment:
+ *    "This product includes software developed by Computing Services
+ *     at Carnegie Mellon University (http://www.cmu.edu/computing/)."
+ *
+ * CARNEGIE MELLON UNIVERSITY DISCLAIMS ALL WARRANTIES WITH REGARD TO
+ * THIS SOFTWARE, INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS, IN NO EVENT SHALL CARNEGIE MELLON UNIVERSITY BE LIABLE
+ * FOR ANY SPECIAL, INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN
+ * AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING
+ * OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include <sys/ioctl.h>
+#include <asm/termbits.h>
+#include <asm/ioctls.h>
+
+int force_baudrate(int fd, int speed)
+{
+	struct termios2 tio;
+	ioctl(fd, TCGETS2, &tio);
+	tio.c_cflag &= ~CBAUD;
+	tio.c_cflag |= BOTHER;
+	tio.c_ispeed = speed;
+	tio.c_ospeed = speed;
+	return ioctl(fd, TCSETS2, &tio);
+}

--- a/pppd/sys-linux-termios2.h
+++ b/pppd/sys-linux-termios2.h
@@ -1,0 +1,3 @@
+/* sys-linux-termios2.h */
+
+int force_baudrate(int fd, int speed);

--- a/pppd/sys-linux.c
+++ b/pppd/sys-linux.c
@@ -124,6 +124,7 @@
 #include "pppd.h"
 #include "fsm.h"
 #include "ipcp.h"
+#include "sys-linux-termios2.h"
 
 #ifdef IPX_CHANGE
 #include "ipxcp.h"
@@ -986,9 +987,9 @@ void set_up_tty(int tty_fd, int local)
  * since that implies that the serial port is disabled.
  */
     else {
-	speed = cfgetospeed(&tios);
-	if (speed == B0)
-	    fatal("Baud rate for %s is 0; need explicit baud rate", devnam);
+	warn("Forcing non standard baudrate %d\n", inspeed);
+	if (force_baudrate(tty_fd, inspeed) == -1)
+	    error("Failed to set non standard baudrate (%d)", errno);
     }
 
     while (tcsetattr(tty_fd, TCSAFLUSH, &tios) < 0 && !ok_error(errno))

--- a/pppd/sys-linux.c
+++ b/pppd/sys-linux.c
@@ -982,19 +982,20 @@ void set_up_tty(int tty_fd, int local)
 	cfsetospeed (&tios, speed);
 	cfsetispeed (&tios, speed);
     }
-/*
- * We can't proceed if the serial port speed is B0,
- * since that implies that the serial port is disabled.
- */
-    else {
-	warn("Forcing non standard baudrate %d\n", inspeed);
-	if (force_baudrate(tty_fd, inspeed) == -1)
-	    error("Failed to set non standard baudrate (%d)", errno);
-    }
 
     while (tcsetattr(tty_fd, TCSAFLUSH, &tios) < 0 && !ok_error(errno))
 	if (errno != EINTR)
 	    fatal("tcsetattr: %m (line %d)", __LINE__);
+
+/*
+ * We can't proceed if the serial port speed is B0,
+ * since that implies that the serial port is disabled.
+ */
+    if (!speed) {
+	warn("Forcing non standard baudrate %d on fd %d\n", inspeed, tty_fd);
+	if (force_baudrate(tty_fd, inspeed) == -1)
+	    error("Failed to set non standard baudrate (%d)", errno);
+    }
 
     baud_rate    = baud_rate_of(speed);
     restore_term = 1;


### PR DESCRIPTION
When an unsupported baudrate is specify, we can force it to the kernel
by using the TCSETS2 ioctl with the BOTHER cflag.

TCSETS2 and struct termios2 are available in asm/termbits.h and
asm/ioctls.h but including these headers conflict with termios.h which
is needed by sys-linux.c.
For that reason, we put the force_baudrate function in a dedicated file.

Signed-off-by: Sylvain Chouleur sylvain.chouleur@gmail.com
