### PR TITLE
PPP iface enhanced to ifnameN

### DIFF
--- a/pppd/main.c
+++ b/pppd/main.c
@@ -730,7 +730,28 @@ set_ifunit(iskey)
     int iskey;
 {
     if (req_ifname[0] != '\0')
-	slprintf(ifname, sizeof(ifname), "%s", req_ifname);
+    {
+	char *ptr;
+	ptr = strchr(req_ifname, 'N');
+
+	if (ptr == NULL)
+	    slprintf(ifname, sizeof(ifname), "%s", req_ifname);
+
+	else {
+	    int index=0;
+	    char req_ifname_t[MAXIFNAMELEN];
+	    index = (int)(ptr - req_ifname);
+	    memset(req_ifname_t, 0, MAXIFNAMELEN); // force cleanup
+	    strncpy(req_ifname_t, req_ifname, index);
+
+	    // Copy the part of the req_ifname which doesn't contains "N"
+	    strncpy(req_ifname_t, req_ifname, index);
+
+	    // Add the ifunit to the end of the interface name
+	    slprintf(ifname, sizeof(ifname), "%s%d", req_ifname_t, ifunit);
+	    info("Using ifname in format ifnameN. Set to new name: '%s'", ifname);
+	}
+    }
     else
 	slprintf(ifname, sizeof(ifname), "%s%d", PPP_DRV_NAME, ifunit);
     info("Using interface %s", ifname);

--- a/pppd/options.c
+++ b/pppd/options.c
@@ -294,7 +294,7 @@ option_t general_options[] = {
       OPT_PRIO | OPT_LLIMIT, 0, 0 },
 
     { "ifname", o_string, req_ifname,
-      "Set PPP interface name",
+      "Set PPP interface name. If format is like ifnameN, N it will be replaced by unit number",
       OPT_PRIO | OPT_PRIV | OPT_STATIC, NULL, MAXIFNAMELEN },
 
     { "dump", o_bool, &dump_options,

--- a/pppd/plugins/radius/radius.c
+++ b/pppd/plugins/radius/radius.c
@@ -39,6 +39,7 @@ static char const RCSID[] =
 #include "ipcp.h"
 #include <syslog.h>
 #include <sys/types.h>
+#include <regex.h>
 #include <sys/time.h>
 #include <string.h>
 #include <netinet/in.h>
@@ -1314,7 +1315,25 @@ static int
 get_client_port(char *ifname)
 {
     int port;
-    if (sscanf(ifname, "ppp%d", &port) == 1) {
+    char cport[10];
+    int reti;
+    regex_t regex;
+    regmatch_t matches[2]; /* Array of matches */
+
+    /* Compile regular expression */
+    reti = regcomp(&regex, "^[[:alpha:]]\\+\\([0-9]\\+\\)$", 0);
+    /* Execute regular expression */
+    reti = regexec(&regex, ifname, 2, matches, 0);
+    regfree(&regex);
+
+    //info("radius.c: get_client_port: %s", ifname);
+
+    if (!reti) {
+        memset(cport, 0, 10); // force cleanup
+        strncpy(cport, ifname + matches[1].rm_so, (int)(matches[1].rm_eo-matches[1].rm_so));
+        port = atoi(cport);
+        //info("radius.c: get_client_port: %s", cport);
+        //info("radius.c: get_client_port: %d", port);
 	return port;
     }
     return rc_map2id(ifname);

--- a/pppd/sys-linux.c
+++ b/pppd/sys-linux.c
@@ -647,15 +647,49 @@ static int make_ppp_unit()
 	if (x == 0 && req_ifname[0] != '\0') {
 		struct ifreq ifr;
 		char t[MAXIFNAMELEN];
-		memset(&ifr, 0, sizeof(struct ifreq));
-		slprintf(t, sizeof(t), "%s%d", PPP_DRV_NAME, ifunit);
-		strncpy(ifr.ifr_name, t, IF_NAMESIZE);
-		strncpy(ifr.ifr_newname, req_ifname, IF_NAMESIZE);
-		x = ioctl(sock_fd, SIOCSIFNAME, &ifr);
-		if (x < 0)
-		    error("Couldn't rename interface %s to %s: %m", t, req_ifname);
-		else
-		    info("Renamed interface %s to %s", t, req_ifname);
+
+		char *ptr;
+		ptr = strchr(req_ifname, 'N');
+
+		if (ptr == NULL) {
+			memset(&ifr, 0, sizeof(struct ifreq));
+			slprintf(t, sizeof(t), "%s%d", PPP_DRV_NAME, ifunit);
+			strncpy(ifr.ifr_name, t, IF_NAMESIZE);
+			strncpy(ifr.ifr_newname, req_ifname, IF_NAMESIZE);
+			x = ioctl(sock_fd, SIOCSIFNAME, &ifr);
+			if (x < 0)
+			    error("Couldn't rename interface %s to %s: %m", t, req_ifname);
+			else
+			    info("Renamed interface %s to %s", t, req_ifname);
+		}
+		else 
+		{
+			int index=0;
+			char t2[MAXIFNAMELEN];
+			char req_ifname_t[MAXIFNAMELEN];
+
+			index = (int)(ptr - req_ifname);
+
+			// Copy the part of the req_ifname which doesn't contains "N"
+			memset(req_ifname_t, 0, MAXIFNAMELEN); // force cleanup
+			strncpy(req_ifname_t, req_ifname, index);
+
+			memset(&ifr, 0, sizeof(struct ifreq));
+
+			slprintf(t, sizeof(t), "%s%d", PPP_DRV_NAME, ifunit);
+			strncpy(ifr.ifr_name, t, IF_NAMESIZE);
+
+			slprintf(t2, sizeof(t2), "%s%d", req_ifname_t, ifunit);
+			strncpy(ifr.ifr_newname, t2, IF_NAMESIZE);
+
+			info("Found ifname in format ifnameN. Using %s as interface", t2);
+
+			x = ioctl(sock_fd, SIOCSIFNAME, &ifr);
+			if (x < 0)
+			    error("Couldn't rename interface %s to %s: %m", t, t2);
+			else
+			    info("Renamed interface %s to %s", t, t2);
+		}
 	}
 
 	return x;


### PR DESCRIPTION
Hi,

Because I'm using this kind of patch for a while, I was thinking to see if you are agree with such change.
Is a small change in pppd and radius-plugin which allows you under Linux to use arbitrary names for the PPP daemon instead using standard naming pppX.
The previous patch in PPP is allowing you to use a fix name for the interface name, not allowing PPP to use unit number in the end.

The idea comes when I've tried to use a script to change the name, but because PPP is allocating by default pppX naming , radius plugin also had issues sending correct interims packets to radius server and the database couldn't be updated correctly and the clients were disconnected because of false inactivity in database.

In this case i've changed the PPP and I've improved the previous patch of fixed naming "ifname" to "ifnameN" with backwards compatibility with "ifname" format.

For example if I have 3 daemons running on same server, one is used for PPTP, other is PPPoE and other is L2TP, then for each daemon I'm creating a ppp configuration file and I'm setting like this:

PPTP:
```
ifname pptpN
```

PPPoE:
```
ifname pppoesN
```

L2TP:
```
ifname lt2pN
```

The daemon will rename the interfaces like:
pptp0, pptp1, pppoes2, l2tp3, pppoes3, pptp4 ..

Which will be a benefit also for the firewall if you want to classify the traffic in specific targets.

Kind regards,
Adrian 