### PR TITLE
Do not accidentaly leak FDs

### DIFF
--- a/pppd/auth.c
+++ b/pppd/auth.c
@@ -475,7 +475,7 @@ setupapfile(char **argv)
         free(fname);
 	return 0;
     }
-    ufile = fopen(fname, "r");
+    ufile = fopen(fname, "re");
     if (seteuid(euid) == -1)
 	fatal("unable to regain privileges: %m");
     if (ufile == NULL) {
@@ -1480,7 +1480,7 @@ check_passwd(int unit,
     filename = _PATH_UPAPFILE;
     addrs = opts = NULL;
     ret = UPAP_AUTHNAK;
-    f = fopen(filename, "r");
+    f = fopen(filename, "re");
     if (f == NULL) {
 	error("Can't open PAP password file %s: %m", filename);
 
@@ -1578,7 +1578,7 @@ null_login(int unit)
     if (ret <= 0) {
 	filename = _PATH_UPAPFILE;
 	addrs = NULL;
-	f = fopen(filename, "r");
+	f = fopen(filename, "re");
 	if (f == NULL)
 	    return 0;
 	check_access(f, filename);
@@ -1624,7 +1624,7 @@ get_pap_passwd(char *passwd)
     }
 
     filename = _PATH_UPAPFILE;
-    f = fopen(filename, "r");
+    f = fopen(filename, "re");
     if (f == NULL)
 	return 0;
     check_access(f, filename);
@@ -1661,7 +1661,7 @@ have_pap_secret(int *lacks_ipp)
     }
 
     filename = _PATH_UPAPFILE;
-    f = fopen(filename, "r");
+    f = fopen(filename, "re");
     if (f == NULL)
 	return 0;
 
@@ -1703,7 +1703,7 @@ have_chap_secret(char *client, char *server,
     }
 
     filename = _PATH_CHAPFILE;
-    f = fopen(filename, "r");
+    f = fopen(filename, "re");
     if (f == NULL)
 	return 0;
 
@@ -1741,7 +1741,7 @@ have_srp_secret(char *client, char *server, int need_ip, int *lacks_ipp)
     struct wordlist *addrs;
 
     filename = _PATH_SRPFILE;
-    f = fopen(filename, "r");
+    f = fopen(filename, "re");
     if (f == NULL)
 	return 0;
 
@@ -1792,7 +1792,7 @@ get_secret(int unit, char *client, char *server,
 	addrs = NULL;
 	secbuf[0] = 0;
 
-	f = fopen(filename, "r");
+	f = fopen(filename, "re");
 	if (f == NULL) {
 	    error("Can't open chap secret file %s: %m", filename);
 	    return 0;
@@ -1845,7 +1845,7 @@ get_srp_secret(int unit, char *client, char *server,
 	filename = _PATH_SRPFILE;
 	addrs = NULL;
 
-	fp = fopen(filename, "r");
+	fp = fopen(filename, "re");
 	if (fp == NULL) {
 	    error("Can't open srp secret file %s: %m", filename);
 	    return 0;
@@ -2236,7 +2236,7 @@ scan_authfile(FILE *f, char *client, char *server,
 	     */
 	    if (word[0] == '@' && word[1] == '/') {
 		strlcpy(atfile, word+1, sizeof(atfile));
-		if ((sf = fopen(atfile, "r")) == NULL) {
+		if ((sf = fopen(atfile, "re")) == NULL) {
 		    warn("can't open indirect secret file %s", atfile);
 		    continue;
 		}

--- a/pppd/options.c
+++ b/pppd/options.c
@@ -446,7 +446,7 @@ options_from_file(char *filename, int must_exist, int check_prot, int priv)
 	option_error("unable to drop privileges to open %s: %m", filename);
 	return 0;
     }
-    f = fopen(filename, "r");
+    f = fopen(filename, "re");
     err = errno;
     if (check_prot && seteuid(euid) == -1)
 	fatal("unable to regain privileges");

--- a/pppd/sys-linux.c
+++ b/pppd/sys-linux.c
@@ -1455,7 +1455,7 @@ static char *path_to_procfs(const char *tail)
 	/* Default the mount location of /proc */
 	strlcpy (proc_path, "/proc", sizeof(proc_path));
 	proc_path_len = 5;
-	fp = fopen(MOUNTED, "r");
+	fp = fopen(MOUNTED, "re");
 	if (fp != NULL) {
 	    while ((mntent = getmntent(fp)) != NULL) {
 		if (strcmp(mntent->mnt_type, MNTTYPE_IGNORE) == 0)
@@ -1515,7 +1515,7 @@ static int open_route_table (void)
     close_route_table();
 
     path = path_to_procfs("/net/route");
-    route_fd = fopen (path, "r");
+    route_fd = fopen (path, "re");
     if (route_fd == NULL) {
 	error("can't open routing table %s: %m", path);
 	return 0;


### PR DESCRIPTION
It's usually better to use CLOEXEC.

Signed-off-by: Jaroslav Škarvada <jskarvad@redhat.com>