### PR TITLE
pppd: fix cross-compilation using Clang

### DIFF
--- a/pppd/Makefile.linux
+++ b/pppd/Makefile.linux
@@ -157,7 +157,6 @@ endif
 
 ifdef NEEDDES
 ifndef USE_CRYPT
-CFLAGS   += -I$(shell $(CC) --print-sysroot)/usr/include/openssl
 NEEDCRYPTOLIB = y
 else
 CFLAGS   += -DUSE_CRYPT=1

--- a/pppd/pppcrypt.h
+++ b/pppd/pppcrypt.h
@@ -38,7 +38,7 @@
 #endif
 
 #ifndef USE_CRYPT
-#include <des.h>
+#include <openssl/des.h>
 #endif
 
 extern bool	DesSetkey(u_char *);


### PR DESCRIPTION
Clang does not have the --print-sysroot option so the shell
snippet silently fails leading to "-I/usr/include/openssl".
Thankfully systems like Gentoo/portage or Yocto/bitbake enable
sysroot poisoning precisely to catch these kinds of bugs.

There is only one user of this non-standard CFLAG include in
pppcrypt.h, so make it consistent with the rest of the sources
(eg. see eap-tls.[h|c] openssl/* includes) and drop the fragile
sysroot hackery.

Signed-off-by: Adrian Ratiu <adrian.ratiu@collabora.com>