### PR TITLE
Allowing storage space for 32-bytes MPPE keying material.

### DIFF
--- a/pppd/ccp.c
+++ b/pppd/ccp.c
@@ -1427,8 +1427,8 @@ ccp_up(fsm *f)
 	notice("%s transmit compression enabled", method_name(ho, NULL));
 #ifdef MPPE
     if (go->mppe) {
-	BZERO(mppe_recv_key, MPPE_MAX_KEY_LEN);
-	BZERO(mppe_send_key, MPPE_MAX_KEY_LEN);
+	BZERO(mppe_recv_key, sizeof(mppe_recv_key));
+	BZERO(mppe_send_key, sizeof(mppe_send_key));
 	continue_networks(f->unit);		/* Bring up IP et al */
     }
 #endif

--- a/pppd/ccp.c
+++ b/pppd/ccp.c
@@ -36,6 +36,7 @@
 #include "pppd.h"
 #include "fsm.h"
 #include "ccp.h"
+#include "mppe.h"
 #include <net/ppp-comp.h>
 
 #ifdef MPPE

--- a/pppd/chap_ms.c
+++ b/pppd/chap_ms.c
@@ -93,6 +93,7 @@
 #include "sha1.h"
 #include "pppcrypt.h"
 #include "magic.h"
+#include "mppe.h"
 
 
 
@@ -120,8 +121,8 @@ bool	ms_lanman = 0;    	/* Use LanMan password instead of NT */
 #endif
 
 #ifdef MPPE
-u_char mppe_send_key[MPPE_MAX_KEY_LEN];
-u_char mppe_recv_key[MPPE_MAX_KEY_LEN];
+u_char mppe_send_key[MAX_MPPE_MATERIAL_LEN];
+u_char mppe_recv_key[MAX_MPPE_MATERIAL_LEN];
 int mppe_keys_set = 0;		/* Have the MPPE keys been set? */
 
 #ifdef DEBUGMPPEKEY
@@ -736,8 +737,8 @@ mppe_set_keys(u_char *rchallenge, u_char PasswordHashHash[MD4_SIGNATURE_SIZE])
     SHA1_Final(Digest, &sha1Context);
 
     /* Same key in both directions. */
-    BCOPY(Digest, mppe_send_key, sizeof(mppe_send_key));
-    BCOPY(Digest, mppe_recv_key, sizeof(mppe_recv_key));
+    BCOPY(Digest, mppe_send_key, MIN(sizeof(Digest), sizeof(mppe_send_key)));
+    BCOPY(Digest, mppe_recv_key, MIN(sizeof(Digest), sizeof(mppe_recv_key)));
 
     mppe_keys_set = 1;
 }
@@ -836,7 +837,7 @@ mppe_set_keys2(u_char PasswordHashHash[MD4_SIGNATURE_SIZE],
     SHA1_Update(&sha1Context, SHApad2, sizeof(SHApad2));
     SHA1_Final(Digest, &sha1Context);
 
-    BCOPY(Digest, mppe_send_key, sizeof(mppe_send_key));
+    BCOPY(Digest, mppe_send_key, MIN(sizeof(Digest), sizeof(mppe_send_key)));
 
     /*
      * generate recv key
@@ -852,7 +853,7 @@ mppe_set_keys2(u_char PasswordHashHash[MD4_SIGNATURE_SIZE],
     SHA1_Update(&sha1Context, SHApad2, sizeof(SHApad2));
     SHA1_Final(Digest, &sha1Context);
 
-    BCOPY(Digest, mppe_recv_key, sizeof(mppe_recv_key));
+    BCOPY(Digest, mppe_recv_key, MIN(sizeof(Digest), sizeof(mppe_recv_key)));
 
     mppe_keys_set = 1;
 }

--- a/pppd/chap_ms.h
+++ b/pppd/chap_ms.h
@@ -68,9 +68,9 @@
 #define MS_CHAP2_FLAGS		48
 
 #ifdef MPPE
-#include "mppe.h"	/* MPPE_MAX_KEY_LEN */
-extern u_char mppe_send_key[MPPE_MAX_KEY_LEN];
-extern u_char mppe_recv_key[MPPE_MAX_KEY_LEN];
+#define MAX_MPPE_MATERIAL_LEN 32
+extern u_char mppe_send_key[MAX_MPPE_MATERIAL_LEN];
+extern u_char mppe_recv_key[MAX_MPPE_MATERIAL_LEN];
 extern int mppe_keys_set;
 
 /* These values are the RADIUS attribute values--see RFC 2548. */

--- a/pppd/eap-tls.c
+++ b/pppd/eap-tls.c
@@ -49,6 +49,7 @@
 #include "fsm.h"
 #include "lcp.h"
 #include "pathnames.h"
+#include "chap_ms.h"
 
 typedef struct pw_cb_data
 {

--- a/pppd/eap-tls.h
+++ b/pppd/eap-tls.h
@@ -85,11 +85,6 @@ int get_eaptls_secret(int unit, char *client, char *server,
               char *capath, char *pkfile, int am_server);
 
 #ifdef MPPE
-#include "mppe.h"   /* MPPE_MAX_KEY_LEN */
-extern u_char mppe_send_key[MPPE_MAX_KEY_LEN];
-extern u_char mppe_recv_key[MPPE_MAX_KEY_LEN];
-extern int mppe_keys_set;
-
 void eaptls_gen_mppe_keys(struct eaptls_session *ets, int client);
 #endif
 


### PR DESCRIPTION
Fix for issue #258 
This *crude* patchset expands the current size of the mppe_send|recv_key buffers to store up to 32 bytes of keying material. Note that the MPPE key passed up to the kernel is still 16 bytes (will not work with larger keys). 

I am not necessarily advocating for taking this fix, but more of a proof of concept. There are probably better ways to encapsulate the keys (e.g write an mppe.c file that allows for set/get/clear of current mppe keys, moving it away from the chap_ms.c file), etc.