### PR TITLE
Fix for issue #218, a logical error in comparing valid encryption policies

### DIFF
--- a/pppd/chap_ms.c
+++ b/pppd/chap_ms.c
@@ -953,7 +953,7 @@ void
 set_mppe_enc_types(int policy, int types)
 {
     /* Early exit for unknown policies. */
-    if (policy != MPPE_ENC_POL_ENC_ALLOWED ||
+    if (policy != MPPE_ENC_POL_ENC_ALLOWED &&
 	policy != MPPE_ENC_POL_ENC_REQUIRED)
 	return;
 


### PR DESCRIPTION
RFC2548 describes the proper values of the MS-MPPE-Encryption-Policy attribute.
and it can only hold 2 values: 1 (encryption allowed) and 2 (encryption required).

See
   https://tools.ietf.org/html/rfc2548, section 2.4.4

The correct comparison should be made with an && and not a ||

Signed-off-by: Eivind Naess <eivnaes@yahoo.com>