### PR TITLE
Allow use of PCKS12 certificates when using EAP-TLS

### DIFF
--- a/README.eap-tls
+++ b/README.eap-tls
@@ -134,6 +134,9 @@ EAP-TLS authentication support for PPP
       key <key-file>
         Use the client private key found in <key-file> in PEM format
         or in engine:engine_id format
+      pkcs12 <pkcs12-file>
+        Use a pkcs12 envelope as a substitute for cert and key. A password may be
+        required to use this file. 
       crl <crl-file>
         Use the Certificate Revocation List (CRL) file <crl-file> in PEM format.
       crl-dir <dir>

--- a/pppd/auth.c
+++ b/pppd/auth.c
@@ -255,6 +255,7 @@ char *cacert_file  = NULL;	/* CA certificate file (pem format) */
 char *ca_path      = NULL;	/* directory with CA certificates */
 char *cert_file    = NULL;	/* client certificate file (pem format) */
 char *privkey_file = NULL;	/* client private key file (pem format) */
+char *pkcs12_file  = NULL;	/* client private key envelope file (pkcs12 format) */
 char *crl_dir      = NULL;	/* directory containing CRL files */
 char *crl_file     = NULL;	/* Certificate Revocation List (CRL) file (pem format) */
 char *max_tls_version = NULL;	/* Maximum TLS protocol version (default=1.2) */
@@ -445,6 +446,7 @@ option_t auth_options[] = {
     { "key", o_string, &privkey_file, "EAP-TLS client private key in PEM format" },
     { "crl-dir", o_string, &crl_dir,  "Use CRLs in directory" },
     { "crl", o_string, &crl_file,     "Use specific CRL file" },
+    { "pkcs12", o_string, &pkcs12_file, "EAP-TLS client credentials in PKCS12 format" },
     { "max-tls-version", o_string, &max_tls_version,
       "Maximum TLS version (1.0/1.1/1.2 (default)/1.3)" },
     { "tls-verify-key-usage", o_bool, &tls_verify_key_usage,
@@ -2464,6 +2466,8 @@ have_eaptls_secret_client(char *client, char *server)
 
 	if ((cacert_file || ca_path) && cert_file && privkey_file)
 		return 1;
+	if (pkcs12_file)
+		return 1;
 
     filename = _PATH_EAPTLSCLIFILE;
     f = fopen(filename, "r");
@@ -2647,7 +2651,7 @@ scan_authfile_eaptls(FILE *f, char *client, char *server,
 int
 get_eaptls_secret(int unit, char *client, char *server,
 		  char *clicertfile, char *servcertfile, char *cacertfile,
-		  char *capath, char *pkfile, int am_server)
+		  char *capath, char *pkfile, char *pkcs12, int am_server)
 {
     FILE *fp;
     int ret;
@@ -2661,6 +2665,7 @@ get_eaptls_secret(int unit, char *client, char *server,
 	bzero(cacertfile, MAXWORDLEN);
 	bzero(capath, MAXWORDLEN);
 	bzero(pkfile, MAXWORDLEN);
+	bzero(pkcs12, MAXWORDLEN);
 
 	/* the ca+cert+privkey can also be specified as options */
 	if (!am_server && (cacert_file || ca_path) && cert_file && privkey_file )
@@ -2671,6 +2676,14 @@ get_eaptls_secret(int unit, char *client, char *server,
 		if (ca_path)
 			strlcpy( capath, ca_path, MAXWORDLEN );
 		strlcpy( pkfile, privkey_file, MAXWORDLEN );
+	}
+    else if (!am_server && pkcs12_file)
+	{
+		strlcpy( pkcs12, pkcs12_file, MAXWORDLEN );
+		if (cacert_file)
+			strlcpy( cacertfile, cacert_file, MAXWORDLEN );
+		if (ca_path)
+			strlcpy( capath, ca_path, MAXWORDLEN );
 	}
 	else
 	{

--- a/pppd/eap-tls.h
+++ b/pppd/eap-tls.h
@@ -70,7 +70,7 @@ struct eaptls_session
 
 
 SSL_CTX *eaptls_init_ssl(int init_server, char *cacertfile, char *capath,
-            char *certfile, char *peer_certfile, char *privkeyfile);
+            char *certfile, char *peer_certfile, char *privkeyfile, char *pkcs12);
 int eaptls_init_ssl_server(eap_state * esp);
 int eaptls_init_ssl_client(eap_state * esp);
 void eaptls_free_session(struct eaptls_session *ets);
@@ -83,7 +83,7 @@ void eaptls_retransmit(struct eaptls_session *ets, u_char ** outp);
 
 int get_eaptls_secret(int unit, char *client, char *server,
               char *clicertfile, char *servcertfile, char *cacertfile,
-              char *capath, char *pkfile, int am_server);
+              char *capath, char *pkfile, char *pkcs12, int am_server);
 
 #ifdef MPPE
 void eaptls_gen_mppe_keys(struct eaptls_session *ets, int client);

--- a/pppd/pppd.h
+++ b/pppd/pppd.h
@@ -344,6 +344,7 @@ extern int	child_wait;	/* # seconds to wait for children at end */
 
 extern char	*crl_dir;
 extern char	*crl_file;
+extern char *pkcs12_file;
 extern char *max_tls_version;
 extern bool tls_verify_key_usage;
 extern char *tls_verify_method;


### PR DESCRIPTION
This implements the ability to specify the option 'pkcs12' to allow users to provide a PKCS12 formatted file as user credentials. I've tested the current code using PEM, Encrypted Key with PEM, PKCS12. Still pending verification of PKCS11 tokens.

Signed-off-by: Eivind Naess <eivnaes@yahoo.com>