### PR TITLE
Fix for Issue #268 - Avoid SIGSEGV and update documentation

### DIFF
--- a/README.eap-tls
+++ b/README.eap-tls
@@ -147,7 +147,9 @@ EAP-TLS authentication support for PPP
       max-tls-version <1.0|1.1|1.2 (default)|1.3>
         Specify the maximum TLS protocol version to negotiate with peers. Defaults
         to TLSv1.2 as the TLSv1.3 code is experimental.
-      verify-tls-peer <none|subject|name|suffix>
+      tls-verify-key-usage
+        Validate certificate purpose and extended key usage
+      tls-verify-method <none|subject|name|suffix>
         Compare the remotename against the subject, certificate name, or
         match by suffix. Default is 'name'.
 

--- a/pppd/eap-tls.c
+++ b/pppd/eap-tls.c
@@ -1206,7 +1206,10 @@ int ssl_verify_callback(int ok, X509_STORE_CTX * ctx)
          * If acting as client and the name of the server wasn't specified
          * explicitely, we can't verify the server authenticity 
          */
-        if (!ets->peer[0] || !strcmp(tls_verify_method, TLS_VERIFY_NONE)) {
+        if (!tls_verify_method)
+            tls_verify_method = TLS_VERIFY_NONE;
+
+        if (!ets->peer[0] || !strcmp(TLS_VERIFY_NONE, tls_verify_method)) {
             warn("Certificate verication disabled or no peer name was specified");
             return ok;
         }


### PR DESCRIPTION
Make sure the variable has a default value. Also, fixing up the README.eap-tls
documentation for the new options.

Signed-off-by: Eivind Naess <eivnaes@yahoo.com>