### PR TITLE
Allow building of EAP-TLS code when OPENSSL_NO_ENGINE is set.

### DIFF
--- a/pppd/eap-tls.c
+++ b/pppd/eap-tls.c
@@ -56,10 +56,12 @@ typedef struct pw_cb_data
     const char *prompt_info;
 } PW_CB_DATA;
 
+#ifndef OPENSSL_NO_ENGINE
 /* The openssl configuration file and engines can be loaded only once */
 static CONF   *ssl_config  = NULL;
 static ENGINE *cert_engine = NULL;
 static ENGINE *pkey_engine = NULL;
+#endif
 
 /* TLSv1.3 do we have a session ticket ? */
 static int have_session_ticket = 0;
@@ -219,7 +221,9 @@ CONF *eaptls_ssl_load_config( void )
     }
 
     dbglog( "Loading OpenSSL built-ins" );
+#ifndef OPENSSL_NO_ENGINE
     ENGINE_load_builtin_engines();
+#endif
     OPENSSL_load_builtin_modules();
    
     dbglog( "Loading OpenSSL configured modules" );
@@ -233,6 +237,7 @@ CONF *eaptls_ssl_load_config( void )
     return config;
 }
 
+#ifndef OPENSSL_NO_ENGINE
 ENGINE *eaptls_ssl_load_engine( char *engine_name )
 {
     ENGINE      *e = NULL;
@@ -277,7 +282,7 @@ ENGINE *eaptls_ssl_load_engine( char *engine_name )
 
     return e;
 }
-
+#endif
 
 
 /*
@@ -287,10 +292,12 @@ ENGINE *eaptls_ssl_load_engine( char *engine_name )
 SSL_CTX *eaptls_init_ssl(int init_server, char *cacertfile, char *capath,
             char *certfile, char *peer_certfile, char *privkeyfile)
 {
+#ifndef OPENSSL_NO_ENGINE
     char        *cert_engine_name = NULL;
     char        *cert_identifier = NULL;
     char        *pkey_engine_name = NULL;
     char        *pkey_identifier = NULL;
+#endif
     SSL_CTX     *ctx;
     SSL         *ssl;
     X509_STORE  *certstore;
@@ -329,11 +336,13 @@ SSL_CTX *eaptls_init_ssl(int init_server, char *cacertfile, char *capath,
     SSL_library_init();
     SSL_load_error_strings();
 
+#ifndef OPENSSL_NO_ENGINE
     /* load the openssl config file only once and load it before triggering
        the loading of a global openssl config file via SSL_CTX_new()
      */
     if (!ssl_config)
         ssl_config = eaptls_ssl_load_config();
+#endif
 
     ctx = SSL_CTX_new(TLS_method());
 
@@ -342,6 +351,7 @@ SSL_CTX *eaptls_init_ssl(int init_server, char *cacertfile, char *capath,
         goto fail;
     }
 
+#ifndef OPENSSL_NO_ENGINE
     /* if the certificate filename is of the form engine:id. e.g.
         pkcs11:12345
        then we try to load and use this engine.
@@ -417,6 +427,7 @@ SSL_CTX *eaptls_init_ssl(int init_server, char *cacertfile, char *capath,
         else
             pkey_engine = eaptls_ssl_load_engine( pkey_engine_name );
     }
+#endif
 
     SSL_CTX_set_default_passwd_cb (ctx, password_callback);
 
@@ -434,6 +445,7 @@ SSL_CTX *eaptls_init_ssl(int init_server, char *cacertfile, char *capath,
     if (init_server)
         SSL_CTX_set_client_CA_list(ctx, SSL_load_client_CA_file(cacertfile));
 
+#ifndef OPENSSL_NO_ENGINE
     if (cert_engine)
     {
         struct
@@ -468,6 +480,7 @@ SSL_CTX *eaptls_init_ssl(int init_server, char *cacertfile, char *capath,
         }
     }
     else
+#endif
     {
         if (!SSL_CTX_use_certificate_chain_file(ctx, certfile))
         {
@@ -504,6 +517,7 @@ SSL_CTX *eaptls_init_ssl(int init_server, char *cacertfile, char *capath,
     }
     SSL_free(ssl);
 
+#ifndef OPENSSL_NO_ENGINE
     if (pkey_engine)
     {
         EVP_PKEY   *pkey = NULL;
@@ -556,6 +570,7 @@ SSL_CTX *eaptls_init_ssl(int init_server, char *cacertfile, char *capath,
         }
     }
     else
+#endif
     {
         if (!SSL_CTX_use_PrivateKey_file(ctx, privkeyfile, SSL_FILETYPE_PEM))
         { 


### PR DESCRIPTION
Allow building of EAP-TLS code when OPENSSL_NO_ENGINE is set.

Signed-off-by: Jan Just Keijser <jan.just.keijser@gmail.com>