### PR TITLE
pppd: Add support for arbitrary baud rates via BOTHER on Linux

### DIFF
--- a/pppd/pppd.8
+++ b/pppd/pppd.8
@@ -55,8 +55,8 @@ non-privileged user.
 .I speed
 An option that is a decimal number is taken as the desired baud rate
 for the serial device.  On systems such as
-4.4BSD and NetBSD, any speed can be specified.  Other systems
-(e.g. Linux, SunOS) only support the commonly-used baud rates.
+Linux, 4.4BSD and NetBSD, any speed can be specified.  Other systems
+(e.g. SunOS) only support the commonly-used baud rates.
 .TP
 .B asyncmap \fImap
 This option sets the Async-Control-Character-Map (ACCM) for this end


### PR DESCRIPTION
Most Linux architectures and drivers support arbitrary baud rate BOTHER
values via TCGETS2 and TCSETS2 ioctls in struct termios2.

This patch implements support for BOTHER and struct termios2 which allows
pppd to use any baud rate on Linux systems where architecture and drivers
have support for it.

By default standard values are used.

Support for BOTHER is enabled during compilation when header files have
appropriate definitions of TCGETS2 and TCSETS2 ioctls.

Because there is no glibc support for BOTHER and struct termios2 yet, pppd
defines own BOTHER macro and struct termios2.