### PR TITLE
ipv6cp: Fix ipv6cp-accept-local and ipv6cp-accept-remote options

### DIFF
--- a/pppd/ipv6cp.c
+++ b/pppd/ipv6cp.c
@@ -239,9 +239,9 @@ static option_t ipv6cp_option_list[] = {
     { "-ipv6", o_bool, &ipv6cp_protent.enabled_flag,
       "Disable IPv6 and IPv6CP", OPT_PRIOSUB | OPT_ALIAS },
 
-    { "ipv6cp-accept-local", o_bool, &ipv6cp_allowoptions[0].accept_local,
+    { "ipv6cp-accept-local", o_bool, &ipv6cp_wantoptions[0].accept_local,
       "Accept peer's interface identifier for us", 1 },
-    { "ipv6cp-accept-remote", o_bool, &ipv6cp_allowoptions[0].accept_remote,
+    { "ipv6cp-accept-remote", o_bool, &ipv6cp_wantoptions[0].accept_remote,
       "Accept peer's interface identifier for itself", 1 },
 
     { "defaultroute6", o_bool, &ipv6cp_wantoptions[0].default_route,


### PR DESCRIPTION
These options are completely broken and ignored because pppd reflects these
options in the incorrect struct ipv6cp_allowoptions. Instead pppd expects
that these options are reflected in struct ipv6cp_wantoptions. Same applies
also for IPv4 code where these options are reflected in struct wantoptions.

This issue can be tested and verified by following command:

    ./pppd noauth asyncmap 0 default-asyncmap novj noaccomp nopcomp nodeflate nobsdcomp nomagic  local nolock nodetach  noip  ipv6 ::2,::1 ipv6cp-accept-local ipv6cp-accept-remote  debug pty "./pppd noauth asyncmap 0 default-asyncmap novj noaccomp nopcomp nodeflate nobsdcomp nomagic  local nolock nodetach  noip  ipv6 ::1:1,::1:2  notty"

First pppd prefer to use IPv6 addresses ::2 and ::1 but accept also any
address suggested by second pppd. Second pppd allows usage only of IPv6
addresses ::1:1 and ::1:2 and does not accept any suggestion by first pppd.

Without this patch first pppd show this output:

    sent [IPV6CP ConfReq id=0x1 <addr fe80::0000:0000:0000:0002>]
    rcvd [IPV6CP ConfReq id=0x1 <addr fe80::0000:0000:0001:0001>]
    sent [IPV6CP ConfNak id=0x1 <addr fe80::0000:0000:0000:0001>]
    rcvd [IPV6CP ConfNak id=0x1 <addr fe80::0000:0000:0001:0002>]
    sent [IPV6CP ConfReq id=0x2 <addr fe80::0000:0000:0000:0002>]
    rcvd [IPV6CP ConfReq id=0x2 <addr fe80::0000:0000:0001:0001>]
    sent [IPV6CP ConfAck id=0x2 <addr fe80::0000:0000:0001:0001>]
    rcvd [IPV6CP ConfAck id=0x2 <addr fe80::0000:0000:0000:0002>]
    local  LL address fe80::0000:0000:0000:0002
    remote LL address fe80::0000:0000:0001:0001

Which means that second pppd did not forced its IPv6 address assignment.

With applying this patch first pppd show output:

    sent [IPV6CP ConfReq id=0x1 <addr fe80::0000:0000:0000:0002>]
    rcvd [IPV6CP ConfReq id=0x1 <addr fe80::0000:0000:0001:0001>]
    sent [IPV6CP ConfAck id=0x1 <addr fe80::0000:0000:0001:0001>]
    rcvd [IPV6CP ConfNak id=0x1 <addr fe80::0000:0000:0001:0002>]
    sent [IPV6CP ConfReq id=0x2 <addr fe80::0000:0000:0001:0002>]
    rcvd [IPV6CP ConfAck id=0x2 <addr fe80::0000:0000:0001:0002>]
    local  LL address fe80::0000:0000:0001:0002
    remote LL address fe80::0000:0000:0001:0001

And now first pppd accepted offer from second pppd, meaning that both
ipv6cp-accept-local and ipv6cp-accept-remote are working.

CC: @sthibaul
Fixes: #145