### PR TITLE
radattr: tighten permissions on radattr file to avoid information lea…

### DIFF
--- a/pppd/plugins/radius/radattr.c
+++ b/pppd/plugins/radius/radattr.c
@@ -20,6 +20,8 @@ static char const RCSID[] =
 #include "pppd.h"
 #include "radiusclient.h"
 #include <stdio.h>
+#include <sys/types.h>
+#include <sys/stat.h>
 
 extern void (*radius_attributes_hook)(VALUE_PAIR *);
 static void print_attributes(VALUE_PAIR *);
@@ -71,9 +73,12 @@ print_attributes(VALUE_PAIR *vp)
     char name[2048];
     char value[2048];
     int cnt = 0;
+    mode_t old_umask;
 
     slprintf(fname, sizeof(fname), "/var/run/radattr.%s", ifname);
+    old_umask = umask(077);
     fp = fopen(fname, "w");
+    umask(old_umask);
     if (!fp) {
 	warn("radattr plugin: Could not open %s for writing: %m", fname);
 	return;


### PR DESCRIPTION
…kage.

Depending on the invoking process's umask it's possible that the radattr
file (which in certain cases can contain crytographic keys) be stored
with permissions such that world-read access is possible, resulting in
sensitive information being leaked to local users.

Signed-off-by: Jaco Kroon <jaco@iewc.co.za>