### PR TITLE
Add RFC8044 dictionary compatibility for IPv4 address

### DIFF
--- a/pppd/plugins/radius/dict.c
+++ b/pppd/plugins/radius/dict.c
@@ -150,7 +150,7 @@ int rc_read_dictionary (char *filename)
 			{
 				type = PW_TYPE_INTEGER;
 			}
-			else if (strcmp (typestr, "ipaddr") == 0)
+			else if (strcmp (typestr, "ipaddr") == 0 || strcmp (typestr, "ipv4addr") == 0)
 			{
 				type = PW_TYPE_IPADDR;
 			}


### PR DESCRIPTION
This patch adds ipv4addr RADIUS data type compatible with RFC8044.
New dictionaries from RADIUS is using ipv4addr instead of old ipaddr data type. This patch is avoiding modification of RADIUS dictionaries to be compatible with PPP.