### PR TITLE
radius: interim and stop frames should not depend on successful start.

### DIFF
--- a/pppd/plugins/radius/radius.c
+++ b/pppd/plugins/radius/radius.c
@@ -108,7 +108,6 @@ static int radius_setmppekeys2(VALUE_PAIR *vp, REQUEST_INFO *req_info);
 #endif
 
 struct radius_state {
-    int accounting_started;
     int initialized;
     int client_port;
     int choose_ip;
@@ -957,12 +956,11 @@ radius_acct_start(void)
 	/* RADIUS server could be down so make this a warning */
 	syslog(LOG_WARNING,
 		"Accounting START failed for %s", rstate.user);
-    } else {
-	rstate.accounting_started = 1;
-	/* Kick off periodic accounting reports */
-	if (rstate.acct_interim_interval) {
-	    TIMEOUT(radius_acct_interim, NULL, rstate.acct_interim_interval);
-	}
+    }
+
+    /* Kick off periodic accounting reports */
+    if (rstate.acct_interim_interval) {
+	TIMEOUT(radius_acct_interim, NULL, rstate.acct_interim_interval);
     }
 }
 
@@ -988,14 +986,9 @@ radius_acct_stop(void)
 	return;
     }
 
-    if (!rstate.accounting_started) {
-	return;
-    }
-
     if (rstate.acct_interim_interval)
 	UNTIMEOUT(radius_acct_interim, NULL);
 
-    rstate.accounting_started = 0;
     rc_avpair_add(&send, PW_ACCT_SESSION_ID, rstate.session_id,
 		   0, VENDOR_NONE);
 
@@ -1137,10 +1130,6 @@ radius_acct_interim(void *ignored)
     int result;
 
     if (!rstate.initialized) {
-	return;
-    }
-
-    if (!rstate.accounting_started) {
 	return;
     }
 


### PR DESCRIPTION
It could simply be that the accounting server is temporarily down, and
any good accounting server should be able to recover from missed
start/stop frames.  In particular Acct-Session-Time on the first seen
interim update or even stop frame allows for determining start time.

Signed-off-by: Jaco Kroon <jaco@iewc.co.za>