### PR TITLE
Using OpenSSL for MD4 isn't compatibile how NTPasswordHash is using it.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ autom4te.cache
 /configure.scan
 /depcomp
 /install-sh
+/test-driver
 /missing
 /INSTALL
 /pppd/stamp-h1
@@ -49,6 +50,10 @@ m4/lt~obsolete.m4
 # Generated Makefile
 Makefile
 Makefile.in
+
+# Test related stuff
+utest_*
+test-suite.log
 
 # Distfiles
 /ppp-*.tar.gz

--- a/pppd/Makefile.am
+++ b/pppd/Makefile.am
@@ -1,5 +1,14 @@
 sbin_PROGRAMS = pppd
 dist_man8_MANS = pppd.8
+check_PROGRAMS = \
+    utest_chap
+
+utest_chap_SOURCES = chap_ms.c pppcrypt.c utils.c
+utest_chap_CPPFLAGS = -DUNIT_TEST
+utest_chap_LDFLAGS =
+
+TESTS = $(check_PROGRAMS)
+
 if WITH_SRP
 sbin_PROGRAMS += srp-entry
 dist_man8_MANS += srp-entry.8
@@ -129,18 +138,27 @@ endif
 
 if !WITH_OPENSSL
 pppd_SOURCES += md5.c md4.c sha1.c
+utest_chap_SOURCES += md5.c md4.c sha1.c
 else
 pppd_CPPFLAGS += $(OPENSSL_INCLUDES)
 pppd_LDFLAGS += $(OPENSSL_LDFLAGS)
+
+utest_chap_CPPFLAGS += $(OPENSSL_INCLUDES)
+utest_chap_LDFLAGS += $(OPENSSL_LDFLAGS)
+utest_chap_LDADD = $(OPENSSL_LIBS)
+
 pppd_LIBS += $(OPENSSL_LIBS)
 if !OPENSSL_HAVE_SHA
 pppd_SOURCES += sha1.c
+utest_chap_SOURCES += sha1.c
 endif
 if !OPENSSL_HAVE_MD4
 pppd_SOURCES += md4.c
+utest_chap_SOURCES += md4.c
 endif
 if !OPENSSL_HAVE_MD5
 pppd_SOURCES += md5.c
+utest_chap_SOURCES += md5.c
 endif
 endif
 

--- a/pppd/chap_ms.c
+++ b/pppd/chap_ms.c
@@ -569,7 +569,7 @@ ascii2unicode(char ascii[], int ascii_len, u_char unicode[])
 static void
 NTPasswordHash(u_char *secret, int secret_len, u_char hash[MD4_SIGNATURE_SIZE])
 {
-#ifdef __NetBSD__
+#if defined(__NetBSD__) || !defined(USE_MD4)
     /* NetBSD uses the libc md4 routines which take bytes instead of bits */
     int			mdlen = secret_len;
 #else
@@ -578,12 +578,14 @@ NTPasswordHash(u_char *secret, int secret_len, u_char hash[MD4_SIGNATURE_SIZE])
     MD4_CTX		md4Context;
 
     MD4Init(&md4Context);
-    /* MD4Update can take at most 64 bytes at a time */
+#if !defined(USE_MD4)
+    /* Internal MD4Update can take at most 64 bytes at a time */
     while (mdlen > 512) {
 	MD4Update(&md4Context, secret, 512);
 	secret += 64;
 	mdlen -= 512;
     }
+#endif
     MD4Update(&md4Context, secret, mdlen);
     MD4Final(hash, &md4Context);
 

--- a/pppd/utils.c
+++ b/pppd/utils.c
@@ -329,6 +329,7 @@ vslprintf(char *buf, int buflen, char *fmt, va_list args)
 		    OUTCHAR(c);
 	    }
 	    continue;
+#ifndef UNIT_TEST
 	case 'P':		/* print PPP packet */
 	    bufinfo.ptr = buf;
 	    bufinfo.len = buflen + 1;
@@ -338,6 +339,7 @@ vslprintf(char *buf, int buflen, char *fmt, va_list args)
 	    buf = bufinfo.ptr;
 	    buflen = bufinfo.len - 1;
 	    continue;
+#endif
 	case 'B':
 	    p = va_arg(args, unsigned char *);
 	    for (n = prec; n > 0; --n) {
@@ -432,6 +434,7 @@ log_packet(u_char *p, int len, char *prefix, int level)
 }
 #endif /* unused */
 
+#ifndef UNIT_TEST
 /*
  * format_packet - make a readable representation of a packet,
  * calling `printer(arg, format, ...)' to output it.
@@ -477,6 +480,7 @@ format_packet(u_char *p, int len, printer_func printer, void *arg)
     else
 	printer(arg, "%.*B", len, p);
 }
+#endif  /* UNIT_TEST */
 
 /*
  * init_pr_log, end_pr_log - initialize and finish use of pr_log.
@@ -603,6 +607,7 @@ logit(int level, char *fmt, va_list args)
     log_write(level, buf);
 }
 
+#ifndef UNIT_TEST
 static void
 log_write(int level, char *buf)
 {
@@ -617,6 +622,13 @@ log_write(int level, char *buf)
 	    log_to_fd = -1;
     }
 }
+#else
+static void
+log_write(int level, char *buf)
+{
+    printf("<%d>: %s\n", level, buf);
+}
+#endif
 
 /*
  * fatal - log an error message and die horribly.
@@ -631,7 +643,11 @@ fatal(char *fmt, ...)
     logit(LOG_ERR, fmt, pvar);
     va_end(pvar);
 
+#ifndef UNIT_TEST
     die(1);			/* as promised */
+#else
+    exit(-1);
+#endif
 }
 
 /*
@@ -735,6 +751,8 @@ dump_packet(const char *tag, unsigned char *p, int len)
     dbglog("%s %P", tag, p, len);
 }
 
+
+#ifndef UNIT_TEST
 /*
  * complete_read - read a full `count' bytes from fd,
  * unless end-of-file or an error other than EINTR is encountered.
@@ -760,6 +778,7 @@ complete_read(int fd, void *buf, size_t count)
 	}
 	return done;
 }
+#endif
 
 /* Procedures for locking the serial device using a lock file. */
 #ifndef LOCK_DIR


### PR DESCRIPTION
Sadly, introducing autotools broke chap authentication. This change fixes it such that the workaround for broken internal MD4 works.

Note, the NTPasswordHash function should probably just call MD4() function directly and md4.c should implement that with the workaround. That way, this silliness isn't exposed and copied to other places (if MD4 would be used again, if ever?) 