### PR TITLE
pppoe: Remove rp-pppoe.so symlink to not conflict with real rp-pppoe.so plugin

### DIFF
--- a/pppd/plugins/pppoe/Makefile.am
+++ b/pppd/plugins/pppoe/Makefile.am
@@ -12,11 +12,3 @@ pppoe_la_SOURCES = plugin.c discovery.c if.c common.c
 
 pppoe_discovery_CPPFLAGS = -I${top_srcdir} -I${top_srcdir}/include
 pppoe_discovery_SOURCES = pppoe-discovery.c debug.c
-
-install-exec-hook:
-	(mkdir -p $(DESTDIR)/$(pppd_plugindir); \
-        cd $(DESTDIR)$(pppd_plugindir); \
-        $(LN_S) -f pppoe.so rp-pppoe.so)
-
-uninstall-hook:
-	(cd $(DESTDIR)$(pppd_plugindir); rm -f rp-pppoe.so)


### PR DESCRIPTION
Backward compatibility symlink is there already for one ppp release. Remove
it for next ppp release to not conflict with real rp-pppoe.so plugin. So
both ppp's pppoe.so and rp's rp-pppoe.so plugins can be installed together.

Now when conversion to automake was done, it is a good time to drop this
problematic symlink from default installation.