### PR TITLE
pppd: Remove usage of incorrect constant MAXIFNAMELEN

### DIFF
--- a/pppd/main.c
+++ b/pppd/main.c
@@ -124,7 +124,7 @@
 
 
 /* interface vars */
-char ifname[MAXIFNAMELEN];	/* Interface name */
+char ifname[IFNAMSIZ];		/* Interface name */
 int ifunit;			/* Interface unit number */
 
 struct channel *the_channel;

--- a/pppd/options.c
+++ b/pppd/options.c
@@ -121,7 +121,7 @@ int	connect_delay = 1000;	/* wait this many ms after connect script */
 int	req_unit = -1;		/* requested interface unit */
 char	path_ipup[MAXPATHLEN];	/* pathname of ip-up script */
 char	path_ipdown[MAXPATHLEN];/* pathname of ip-down script */
-char	req_ifname[MAXIFNAMELEN];	/* requested interface name */
+char	req_ifname[IFNAMSIZ];	/* requested interface name */
 bool	multilink = 0;		/* Enable multilink operation */
 char	*bundle_name = NULL;	/* bundle name for multilink */
 bool	dump_options;		/* print out option values */
@@ -299,7 +299,7 @@ option_t general_options[] = {
 
     { "ifname", o_string, req_ifname,
       "Set PPP interface name",
-      OPT_PRIO | OPT_PRIV | OPT_STATIC, NULL, MAXIFNAMELEN },
+      OPT_PRIO | OPT_PRIV | OPT_STATIC, NULL, IFNAMSIZ },
 
     { "dump", o_bool, &dump_options,
       "Print out option values after parsing all options", 1 },

--- a/pppd/pppd.h
+++ b/pppd/pppd.h
@@ -60,6 +60,7 @@
 #include <sys/types.h>		/* for u_int32_t, if defined */
 #include <sys/time.h>		/* for struct timeval */
 #include <net/ppp_defs.h>
+#include <net/if.h>
 #include "patchlevel.h"
 
 #ifdef INET6
@@ -75,8 +76,6 @@
 #define MAXARGS		1	/* max # args to a command */
 #define MAXNAMELEN	256	/* max length of hostname or name for auth */
 #define MAXSECRETLEN	256	/* max length of password or secret */
-#define MAXIFNAMELEN	32	/* max length of interface name; or use IFNAMSIZ, can we
-				   always include net/if.h? */
 
 /*
  * If PPP_DRV_NAME is not defined, use the default "ppp" as the device name.
@@ -329,7 +328,7 @@ extern int	max_data_rate;	/* max bytes/sec through charshunt */
 extern int	req_unit;	/* interface unit number to use */
 extern char	path_ipup[MAXPATHLEN]; /* pathname of ip-up script */
 extern char	path_ipdown[MAXPATHLEN]; /* pathname of ip-down script */
-extern char	req_ifname[MAXIFNAMELEN]; /* interface name to use */
+extern char	req_ifname[IFNAMSIZ]; /* interface name to use */
 extern bool	multilink;	/* enable multilink operation */
 extern bool	noendpoint;	/* don't send or accept endpt. discrim. */
 extern char	*bundle_name;	/* bundle name for multilink */

--- a/pppd/sys-linux.c
+++ b/pppd/sys-linux.c
@@ -697,7 +697,7 @@ static int make_ppp_unit(void)
 
 	if (x == 0 && req_ifname[0] != '\0') {
 		struct ifreq ifr;
-		char t[MAXIFNAMELEN];
+		char t[IFNAMSIZ];
 		memset(&ifr, 0, sizeof(struct ifreq));
 		slprintf(t, sizeof(t), "%s%d", PPP_DRV_NAME, ifunit);
 		strlcpy(ifr.ifr_name, t, IF_NAMESIZE);

--- a/pppd/sys-linux.c
+++ b/pppd/sys-linux.c
@@ -700,8 +700,8 @@ static int make_ppp_unit(void)
 		char t[IFNAMSIZ];
 		memset(&ifr, 0, sizeof(struct ifreq));
 		slprintf(t, sizeof(t), "%s%d", PPP_DRV_NAME, ifunit);
-		strlcpy(ifr.ifr_name, t, IF_NAMESIZE);
-		strlcpy(ifr.ifr_newname, req_ifname, IF_NAMESIZE);
+		strlcpy(ifr.ifr_name, t, IFNAMSIZ);
+		strlcpy(ifr.ifr_newname, req_ifname, IFNAMSIZ);
 		x = ioctl(sock_fd, SIOCSIFNAME, &ifr);
 		if (x < 0)
 		    error("Couldn't rename interface %s to %s: %m", t, req_ifname);


### PR DESCRIPTION
MAXIFNAMELEN is currently hardcoded to 32, but maximal size of interface
name on Linux is just 15 + nul-term byte. This limit is already provided by
IFNAMSIZ macro defined in net/if.h header file.

So replace MAXIFNAMELEN usage by IFNAMSIZ to not silently truncate
interface name.

___

pppd: Replace IF_NAMESIZE by IFNAMSIZ for struct ifreq

Macros IF_NAMESIZE and IFNAMSIZ should be defined to the same value, but
struct ifreq uses IFNAMSIZ. So use "correct" macro.