### PR TITLE
pppol2tp.c add '#ifdef INET6' for optional ipv6

### DIFF
--- a/pppd/plugins/pppol2tp/pppol2tp.c
+++ b/pppd/plugins/pppol2tp/pppol2tp.c
@@ -509,8 +509,10 @@ void plugin_init(void)
 	 */
 	add_notifier(&ip_up_notifier, pppol2tp_ip_up, NULL);
 	add_notifier(&ip_down_notifier, pppol2tp_ip_down, NULL);
+#ifdef INET6
 	add_notifier(&ipv6_up_notifier, pppol2tp_ip_up, NULL);
 	add_notifier(&ipv6_down_notifier, pppol2tp_ip_down, NULL);
+#endif
 }
 
 struct channel pppol2tp_channel = {


### PR DESCRIPTION
Without it, l2tp daemon can't launch ppp, cuz undefined symbol ipv6_up_notifier.