### PR TITLE
add ipv6-{up,down}-script options

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,10 @@
+What's new since ppp-2.4.9 (unreleased)
+***************************************
+
+* New pppd options:
+  - ipv6-up-script
+  - ipv6-down-script
+
 What's new in ppp-2.4.9.
 ************************
 

--- a/pppd/ipv6cp.c
+++ b/pppd/ipv6cp.c
@@ -1322,7 +1322,7 @@ ipv6cp_up(fsm *f)
      */
     if (ipv6cp_script_state == s_down && ipv6cp_script_pid == 0) {
 	ipv6cp_script_state = s_up;
-	ipv6cp_script(_PATH_IPV6UP);
+	ipv6cp_script(path_ipv6up);
     }
 }
 
@@ -1373,7 +1373,7 @@ ipv6cp_down(fsm *f)
     /* Execute the ipv6-down script */
     if (ipv6cp_script_state == s_up && ipv6cp_script_pid == 0) {
 	ipv6cp_script_state = s_down;
-	ipv6cp_script(_PATH_IPV6DOWN);
+	ipv6cp_script(path_ipv6down);
     }
 }
 
@@ -1411,13 +1411,13 @@ ipv6cp_script_done(void *arg)
     case s_up:
 	if (ipv6cp_fsm[0].state != OPENED) {
 	    ipv6cp_script_state = s_down;
-	    ipv6cp_script(_PATH_IPV6DOWN);
+	    ipv6cp_script(path_ipv6down);
 	}
 	break;
     case s_down:
 	if (ipv6cp_fsm[0].state == OPENED) {
 	    ipv6cp_script_state = s_up;
-	    ipv6cp_script(_PATH_IPV6UP);
+	    ipv6cp_script(path_ipv6up);
 	}
 	break;
     }

--- a/pppd/main.c
+++ b/pppd/main.c
@@ -300,6 +300,10 @@ main(int argc, char *argv[])
     strlcpy(path_ipup, _PATH_IPUP, sizeof(path_ipup));
     strlcpy(path_ipdown, _PATH_IPDOWN, sizeof(path_ipdown));
 
+#ifdef INET6
+    strlcpy(path_ipv6up, _PATH_IPV6UP, sizeof(path_ipv6up));
+    strlcpy(path_ipv6down, _PATH_IPV6DOWN, sizeof(path_ipv6down));
+#endif
     link_stats_valid = 0;
     new_phase(PHASE_INITIALIZE);
 

--- a/pppd/options.c
+++ b/pppd/options.c
@@ -131,6 +131,11 @@ int	child_wait = 5;		/* # seconds to wait for children at exit */
 struct userenv *userenv_list;	/* user environment variables */
 int	dfl_route_metric = -1;	/* metric of the default route to set over the PPP link */
 
+#ifdef INET6
+char	path_ipv6up[MAXPATHLEN];   /* pathname of ipv6-up script */
+char	path_ipv6down[MAXPATHLEN]; /* pathname of ipv6-down script */
+#endif
+
 #ifdef MAXOCTETS
 unsigned int  maxoctets = 0;    /* default - no limit */
 int maxoctets_dir = 0;       /* default - sum of traffic */
@@ -327,6 +332,15 @@ option_t general_options[] = {
     { "ip-down-script", o_string, path_ipdown,
       "Set pathname of ip-down script",
       OPT_PRIV|OPT_STATIC, NULL, MAXPATHLEN },
+
+#ifdef INET6
+    { "ipv6-up-script", o_string, path_ipv6up,
+      "Set pathname of ipv6-up script",
+      OPT_PRIV|OPT_STATIC, NULL, MAXPATHLEN },
+    { "ipv6-down-script", o_string, path_ipv6down,
+      "Set pathname of ipv6-down script",
+      OPT_PRIV|OPT_STATIC, NULL, MAXPATHLEN },
+#endif
 
 #ifdef HAVE_MULTILINK
     { "multilink", o_bool, &multilink,

--- a/pppd/pppd.h
+++ b/pppd/pppd.h
@@ -336,6 +336,11 @@ extern bool	dump_options;	/* print out option values */
 extern bool	dryrun;		/* check everything, print options, exit */
 extern int	child_wait;	/* # seconds to wait for children at end */
 
+#ifdef INET6
+extern char	path_ipv6up[MAXPATHLEN]; /* pathname of ipv6-up script */
+extern char	path_ipv6down[MAXPATHLEN]; /* pathname of ipv6-down script */
+#endif
+
 #if defined(USE_EAPTLS) || defined(USE_PEAP)
 
 #define TLS_VERIFY_NONE     "none"


### PR DESCRIPTION
These allow a user to specify the paths to the scripts
usually located at /etc/ppp/ipv6-up and /etc/ppp/ipv6-down,
similarly to the existing ip-up-script and ip-down-script
options

Signed-off-by: Daniel Barlow <dan@telent.net>