### PR TITLE
Fix Solaris CI build.

### DIFF
--- a/.github/workflows/solaris.yaml
+++ b/.github/workflows/solaris.yaml
@@ -3,12 +3,12 @@ on: [push, pull_request]
 
 jobs:
   solaris:
-    runs-on: macos-latest
+    runs-on: macos-10.15
     steps:
     - name: Checkout PPP sources
       uses: actions/checkout@v2
     - name: Build
-      uses: vmactions/solaris-vm@v0.0.1
+      uses: vmactions/solaris-vm@v0.0.4
       with:
         run: |
           pkg update


### PR DESCRIPTION
The Solaris GitHub action is sticking with macOS 10.15 because the new macOS 11 (that now replaces `macos-latest` image) does not contain the needed VirtualBox software. We will migrate the CI to use the latest macOS image when both the GitHub action and the macOS 11 image are ready.
See [actions/virtual-environments#4060](https://github.com/actions/virtual-environments/issues/4060) and [actions/virtual-environments#4010](https://github.com/actions/virtual-environments/pull/4010).