### PR TITLE
ipv6cp: Add support for new ipv6cp-noremote, ipv6cp-nosend and ipv6cp-use-remotenumber options

### DIFF
--- a/pppd/ipv6cp.c
+++ b/pppd/ipv6cp.c
@@ -268,6 +268,8 @@ static option_t ipv6cp_option_list[] = {
     { "ipv6cp-noremote", o_bool, &ipv6cp_noremote,
       "Allow peer to have no interface identifier", 1 },
 #endif
+    { "ipv6cp-nosend", o_bool, &ipv6cp_wantoptions[0].neg_ifaceid,
+      "Don't send local interface identifier to peer", OPT_A2CLR },
 
     { "ipv6cp-restart", o_int, &ipv6cp_fsm[0].timeouttime,
       "Set timeout for IPv6CP", OPT_PRIO },
@@ -684,6 +686,7 @@ bad:
 static int
 ipv6cp_nakci(fsm *f, u_char *p, int len, int treat_as_reject)
 {
+    ipv6cp_options *wo = &ipv6cp_wantoptions[f->unit];
     ipv6cp_options *go = &ipv6cp_gotoptions[f->unit];
     u_char citype, cilen, *next;
     u_short cishort;
@@ -732,7 +735,7 @@ ipv6cp_nakci(fsm *f, u_char *p, int len, int treat_as_reject)
 		     try.neg_ifaceid = 0;
 		 } else if (go->accept_local && !eui64_iszero(ifaceid) && !eui64_equals(ifaceid, go->hisid)) {
 		     try.ourid = ifaceid;
-		 } else if (eui64_iszero(ifaceid) && !go->opt_local) {
+		 } else if (eui64_iszero(ifaceid) && !go->opt_local && wo->neg_ifaceid) {
 		     while (eui64_iszero(ifaceid) || 
 			    eui64_equals(ifaceid, go->hisid)) /* bad luck */
 			 eui64_magic(ifaceid);
@@ -786,7 +789,7 @@ ipv6cp_nakci(fsm *f, u_char *p, int len, int treat_as_reject)
 	    eui64_get(ifaceid, p);
 	    if (go->accept_local && !eui64_iszero(ifaceid) && !eui64_equals(ifaceid, go->hisid)) {
 		try.ourid = ifaceid;
-	    } else if (eui64_iszero(ifaceid) && !go->opt_local) {
+	    } else if (eui64_iszero(ifaceid) && !go->opt_local && wo->neg_ifaceid) {
 		while (eui64_iszero(ifaceid) || 
 		       eui64_equals(ifaceid, go->hisid)) /* bad luck */
 		    eui64_magic(ifaceid);

--- a/pppd/ipv6cp.h
+++ b/pppd/ipv6cp.h
@@ -156,6 +156,7 @@ typedef struct ipv6cp_options {
     int opt_remote;		/* histoken set by option */
     int use_ip;			/* use IP as interface identifier */
     int use_persistent;		/* use uniquely persistent value for address */
+    int use_remotenumber;	/* use remote number value for address */
     int neg_vj;			/* Van Jacobson Compression? */
     u_short vj_protocol;	/* protocol value to use in VJ option */
     eui64_t ourid, hisid;	/* Interface identifiers */

--- a/pppd/pppd.8
+++ b/pppd/pppd.8
@@ -536,6 +536,19 @@ With this option, pppd will accept the peer's idea of its (remote)
 IPv6 interface identifier, even if the remote IPv6 interface
 identifier was specified in an option.
 .TP
+.B ipv6cp\-noremote
+Allow pppd to operate without having an IPv6 link local address for the peer.
+This option is only available under Linux.  Normally, pppd will request the
+peer's IPv6 interface identifier (used for composing IPv6 link local address),
+and if the peer does not supply it, pppd will generate one for the peer.
+With this option, if the peer does not supply its IPv6 interface identifier,
+pppd will not ask the peer for it, and will not set the destination IPv6
+link local address of the ppp interface.  In this situation, the ppp interface
+can be used for routing by creating device routes, but the peer itself cannot
+be addressed directly for IPv6 traffic until the peer starts announcing ICMPv6
+Router Advertisement or ICMPv6 Neighbor Advertisement packets.  Note that IPv6
+router must announce ICMPv6 Router Advertisement packets.
+.TP
 .B ipv6cp\-max\-configure \fIn
 Set the maximum number of IPv6CP configure-request transmissions to
 \fIn\fR (default 10).

--- a/pppd/pppd.8
+++ b/pppd/pppd.8
@@ -549,6 +549,10 @@ be addressed directly for IPv6 traffic until the peer starts announcing ICMPv6
 Router Advertisement or ICMPv6 Neighbor Advertisement packets.  Note that IPv6
 router must announce ICMPv6 Router Advertisement packets.
 .TP
+.B ipv6cp\-nosendip
+Don't send our local IPv6 interface identifier to peer during IPv6 interface
+identifier negotiation.
+.TP
 .B ipv6cp\-max\-configure \fIn
 Set the maximum number of IPv6CP configure-request transmissions to
 \fIn\fR (default 10).

--- a/pppd/pppd.8
+++ b/pppd/pppd.8
@@ -212,11 +212,14 @@ Set the local and/or remote 64-bit interface identifier. Either one may be
 omitted. The identifier must be specified in standard ASCII notation of
 IPv6 addresses (e.g. ::dead:beef). If the
 \fIipv6cp\-use\-ipaddr\fR
-option is given, the local identifier is the local IPv4 address (see above).
+option is given, the local identifier is the local IPv4 address and the
+remote identifier is the remote IPv4 address (see above).
+If the \fIipv6cp-use-remotenumber\fR option is given, the remote identifier
+is set to the value from \fIremotenumber\fR option.
 On systems which supports a unique persistent id, such as EUI\-48 derived
 from the Ethernet MAC address, \fIipv6cp\-use\-persistent\fR option can be
-used to replace the \fIipv6 <local>,<remote>\fR option. Otherwise the 
-identifier is randomized.
+used to set local identifier.  Otherwise both local and remote identifiers
+are randomized.
 .TP
 .B active\-filter \fIfilter\-expression
 Specifies a packet filter to be applied to data packets to determine


### PR DESCRIPTION
IPv6 option `ipv6cp-noremote` is same as IPv4 `noremoteip` option.

IPv6 option `ipv6cp-nosend` is same as IPv4 `nosendip` option.

And option `ipv6cp-use-remotenumber` instruct pppd to use IPv6 remote interface identifier from `remotenumber` option. Useful e.g. for PPPoE connections to generate stable and predicable IPv6 remote interface identifier as `remotenumber` is set by pppoe.so plugin to MAC address of remote ethernet peer.