### PR TITLE
pppoe-discovery: Do not set eth0 as default interface and valide all cmdline options

### DIFF
--- a/pppd/plugins/pppoe/pppoe-discovery.8
+++ b/pppd/plugins/pppoe/pppoe-discovery.8
@@ -26,7 +26,7 @@ Under Linux, it is typically eth0 or eth1.
 The interface should be \(lqup\(rq before you start
 \fBpppoe\-discovery\fR, but should \fInot\fR be configured to have an
 IP address.
-The default interface is eth0.
+This option is mandatory.
 .RE
 .TP
 .BI \-D " file_name"

--- a/pppd/plugins/pppoe/pppoe-discovery.c
+++ b/pppd/plugins/pppoe/pppoe-discovery.c
@@ -251,6 +251,12 @@ int main(int argc, char *argv[])
 	}
     }
 
+    if (optind != argc) {
+	fprintf(stderr, "%s: extra argument '%s'\n", argv[0], argv[optind]);
+	usage();
+	exit(EXIT_FAILURE);
+    }
+
     if (!conn->ifName) {
 	fprintf(stderr, "Interface was not specified\n");
 	exit(EXIT_FAILURE);

--- a/pppd/plugins/pppoe/pppoe-discovery.c
+++ b/pppd/plugins/pppoe/pppoe-discovery.c
@@ -251,9 +251,10 @@ int main(int argc, char *argv[])
 	}
     }
 
-    /* default interface name */
-    if (!conn->ifName)
-	conn->ifName = xstrdup("eth0");
+    if (!conn->ifName) {
+	fprintf(stderr, "Interface was not specified\n");
+	exit(EXIT_FAILURE);
+    }
 
     conn->sessionSocket = -1;
 
@@ -276,7 +277,7 @@ usage(void)
 {
     fprintf(stderr, "Usage: pppoe-discovery [options]\n");
     fprintf(stderr, "Options:\n");
-    fprintf(stderr, "   -I if_name     -- Specify interface (default eth0)\n");
+    fprintf(stderr, "   -I if_name     -- Specify interface (mandatory option)\n");
     fprintf(stderr, "   -D filename    -- Log debugging information in filename.\n");
     fprintf(stderr,
 	    "   -t timeout     -- Initial timeout for discovery packets in seconds\n"

--- a/pppd/plugins/pppoe/pppoe-discovery.c
+++ b/pppd/plugins/pppoe/pppoe-discovery.c
@@ -24,32 +24,6 @@
 
 #include "pppoe.h"
 
-#ifdef HAVE_UNISTD_H
-#include <unistd.h>
-#endif
-
-#ifdef HAVE_NETPACKET_PACKET_H
-#include <netpacket/packet.h>
-#elif defined(HAVE_LINUX_IF_PACKET_H)
-#include <linux/if_packet.h>
-#endif
-
-#ifdef HAVE_ASM_TYPES_H
-#include <asm/types.h>
-#endif
-
-#ifdef HAVE_SYS_IOCTL_H
-#include <sys/ioctl.h>
-#endif
-
-#include <errno.h>
-#include <stdlib.h>
-#include <string.h>
-
-#ifdef HAVE_NET_IF_ARP_H
-#include <net/if_arp.h>
-#endif
-
 int debug;
 int got_sigterm;
 int pppoe_verbose;


### PR DESCRIPTION
On most Linux systems there is no network interface with name eth0.

So rather make -I interface option as mandatory and do not rely on some default hardcoded interface name.

Also there is no sane default interface choice on systems with more interfaces.

Fixes: #219