### PR TITLE
Need to update the esp->ea_client.ea_namelen variable

### DIFF
--- a/pppd/eap.c
+++ b/pppd/eap.c
@@ -2182,6 +2182,7 @@ eap_request(eap_state *esp, u_char *inp, int id, int len)
 		    eap_send_nak(esp, id, EAPT_SRP);
 		    break;
 		}
+		esp->es_client.ea_namelen = strlen(esp->es_client.ea_name);
 
 		/* Create the MSCHAPv2 response (and add to cache) */
 		unsigned char response[MS_CHAP2_RESPONSE_LEN+1]; // VLEN + VALUE


### PR DESCRIPTION
Need to be able to set the correct length of the username before calling chap/chams make_response.

Signed-off-by: Eivind Næss <eivnaes@yahoo.com>