### PR TITLE
pppd/eap-tls.c: fix build with libressl

### DIFF
--- a/pppd/eap-tls.c
+++ b/pppd/eap-tls.c
@@ -61,7 +61,7 @@
 #include "mppe.h"
 #include "pathnames.h"
 
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
+#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
 #define SSL3_RT_HEADER  0x100
 #endif
 


### PR DESCRIPTION
Fix the following build failure with libressl:

```
eap-tls.c: In function 'ssl_msg_callback':
eap-tls.c:1284:10: error: 'SSL3_RT_HEADER' undeclared (first use in this function); did you mean 'SSL3_RT_ALERT'?
 1284 |     case SSL3_RT_HEADER:
      |          ^~~~~~~~~~~~~~
      |          SSL3_RT_ALERT
```

Fixes:
 - http://autobuild.buildroot.org/results/7d721833bddf73531fa03b0a626511af6826d0df

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>