### PR TITLE
pppd/ipv6cp: Add ipv6-pre-up script.

### DIFF
--- a/pppd/pathnames.h
+++ b/pppd/pathnames.h
@@ -60,6 +60,7 @@
 #define	_PATH_PSEUDONYM	 ".ppp_pseudonym"
 
 #ifdef INET6
+#define _PATH_IPV6PREUP	 _ROOT_PATH "/etc/ppp/ipv6-pre-up"
 #define _PATH_IPV6UP     _ROOT_PATH "/etc/ppp/ipv6-up"
 #define _PATH_IPV6DOWN   _ROOT_PATH "/etc/ppp/ipv6-down"
 #endif

--- a/pppd/pppd.8
+++ b/pppd/pppd.8
@@ -1839,6 +1839,11 @@ IP addresses assigned but is still down.  This can be used to
 add firewall rules before any IP traffic can pass through the
 interface.  Pppd will wait for this script to finish before bringing
 the interface up, so this script should run quickly.
+
+It has to be noted that if IPv6 is also in use, it's possible that IPv6CP will
+complete prior to IPCP and will result in the interface already being UP when
+this script is executed.  Only one of ip\-pre\-up and ipv6\-pre\-up will be
+executed with the interface still down.
 .TP
 .B /etc/ppp/ip\-up
 A program or script which is executed when the link is available for
@@ -1855,6 +1860,20 @@ used for undoing the effects of the /etc/ppp/ip\-up and
 /etc/ppp/ip\-pre\-up scripts.  It is
 invoked in the same manner and with the same parameters as the ip\-up
 script.
+.TP
+.B /etc/ppp/ipv6\-pre\-up
+A program or script which is executed just before the ppp network
+interface is brought up for IPv6.  It is executed with the same parameters as
+the ipv6\-up script (below).  At this point the interface exists and has
+IP addresses assigned but is still down.  This can be used to
+add firewall rules before any IP traffic can pass through the
+interface.  Pppd will wait for this script to finish before bringing
+the interface up, so this script should run quickly.
+
+It has to be noted that if IPv4 is also in use, it's possible that IPCP will
+complete prior to IPv6CP and will result in the interface already being UP when
+this script is executed.  Only one of ip\-pre\-up and ipv6\-pre\-up will be
+executed with the interface still down.
 .TP
 .B /etc/ppp/ipv6\-up
 Like /etc/ppp/ip\-up, except that it is executed when the link is available 


### PR DESCRIPTION
This is required because either ipcp or ipv6cp can come up first, or as
the only protocol, and once IPv6 parameters has been established, there
are actions that may need to be executed prior to bringing the interface
up.

Prior to this we can have an execution order like:

pppd[26615]: Script /etc/ppp/ipv6-up started (pid 28183)
pppd[26615]: Script /etc/ppp/ip-pre-up started (pid 28186)
pppd[26615]: Script /etc/ppp/ip-pre-up finished (pid 28186), status = 0x0
pppd[26615]: Script /etc/ppp/ip-up started (pid 28238)
pppd[26615]: Script /etc/ppp/ipv6-up finished (pid 28183), status = 0x0
pppd[26615]: Script /etc/ppp/ip-up finished (pid 28238), status = 0x0

ip ad sh shows that during ip-pre-up the interface state was already up:

ppp-ip-pre-up(ppp1)[28208]: 423: ppp1: <POINTOPOINT,MULTICAST,NOARP,UP,LOWER_UP> mtu 1480 qdisc pfifo_fast state UNKNOWN group default qlen 3
ppp-ip-pre-up(ppp1)[28208]:     link/ppp
ppp-ip-pre-up(ppp1)[28208]:     inet 10.1.0.0 peer 192.168.50.0/32 scope global ppp1
ppp-ip-pre-up(ppp1)[28208]:        valid_lft forever preferred_lft forever
ulsdns_monitor[28216]: 192.168.50.0 dev ppp1 proto kernel scope link src 10.1.0.0
ppp-ip-pre-up(ppp1)[28208]:     inet6 fe80::b4a3:c896:22bc:151f peer fe80::6/128 scope link
ppp-ip-pre-up(ppp1)[28208]:        valid_lft forever preferred_lft forever

In order to make this work properly, a system admin would need to take
the same action from ip-up and ipv6-up (probably in a locked manner) if
and only if the interface oper status is down.

As things stand one cannot depende on ip-up being executed whilst
interface is still in down state, and as such, the scription in the man
page is wrong too.