### PR TITLE
pppd/auth: additionally pass ipparam.

### DIFF
--- a/pppd/auth.c
+++ b/pppd/auth.c
@@ -2407,7 +2407,8 @@ auth_script(char *script)
     argv[3] = user_name;
     argv[4] = devnam;
     argv[5] = strspeed;
-    argv[6] = NULL;
+    argv[6] = ipparam;
+    argv[7] = NULL;
 
     auth_script_pid = run_program(script, argv, 0, auth_script_done, NULL, 0);
 }

--- a/pppd/eap.c
+++ b/pppd/eap.c
@@ -2182,6 +2182,7 @@ eap_request(eap_state *esp, u_char *inp, int id, int len)
 		    eap_send_nak(esp, id, EAPT_SRP);
 		    break;
 		}
+		esp->es_client.ea_namelen = strlen(esp->es_client.ea_name);
 
 		/* Create the MSCHAPv2 response (and add to cache) */
 		unsigned char response[MS_CHAP2_RESPONSE_LEN+1]; // VLEN + VALUE

--- a/pppd/pppd.8
+++ b/pppd/pppd.8
@@ -524,7 +524,8 @@ Set the IPCP restart interval (retransmission timeout) to \fIn\fR
 seconds (default 3).
 .TP
 .B ipparam \fIstring
-Provides an extra parameter to the ip\-up, ip\-pre\-up and ip\-down
+Provides an extra parameter most of the notification scripts, most notably
+ip\-up, ip\-pre\-up, ip\-down, ipv6\-up, ipv6\-down, auth\-up and auth\-down
 scripts.  If this
 option is given, the \fIstring\fR supplied is given as the 6th
 parameter to those scripts.
@@ -1821,7 +1822,7 @@ if they don't exist.
 A program or script which is executed after the remote system
 successfully authenticates itself.  It is executed with the parameters
 .IP
-\fIinterface\-name peer\-name user\-name tty\-device speed\fR
+\fIinterface\-name peer\-name user\-name tty\-device speed ipparam\fR
 .IP
 Note that this script is not executed if the peer doesn't authenticate
 itself, for example when the \fInoauth\fR option is used.


### PR DESCRIPTION
ipparam is the only way a system administrator has of passing arbitrary
information from options files to scripts, and this may be useful during
auth-up and/or auth-fail (I know we need it).

Signed-off-by: Jaco Kroon <jaco@uls.co.za>