### PR TITLE
pppd: Fix build without openssl

### DIFF
--- a/pppd/Makefile.am
+++ b/pppd/Makefile.am
@@ -149,6 +149,7 @@ libppp_crypt_la_SOURCES=
 
 if !WITH_OPENSSL
 libppp_crypt_la_SOURCES += md4.c md5.c sha1.c
+libppp_crypt_la_CPPFLAGS = -I${top_srcdir}/include
 else
 libppp_crypt_la_CPPFLAGS=$(OPENSSL_INCLUDES)
 libppp_crypt_la_LDFLAGS=$(OPENSSL_LDFLAGS)


### PR DESCRIPTION
It cannot find headers when compiling without openssl