### PR TITLE
pppd: Fix build without srp

### DIFF
--- a/pppd/Makefile.am
+++ b/pppd/Makefile.am
@@ -10,8 +10,10 @@ utest_peap_SOURCES = peap.c utils.c mppe.c
 utest_peap_CPPFLAGS = -DUNIT_TEST -I${top_srcdir}/include
 utest_peap_LDFLAGS =
 
+EXTRA_PROGRAMS =
+
 if WITH_SRP
-sbin_PROGRAMS += srp-entry
+EXTRA_PROGRAMS += srp-entry
 dist_man8_MANS += srp-entry.8
 endif
 


### PR DESCRIPTION
It compile srp-entry binary even if --without-srp is specified.
Fix the issue by moving srp-entry to EXTRA_PROGRAMS