### PR TITLE
pppd: Workaround generating of ppp unit id on Linux

### DIFF
--- a/pppd/sys-linux.c
+++ b/pppd/sys-linux.c
@@ -684,6 +684,11 @@ static int make_ppp_unit(void)
 		ifunit = -1;
 		x = ioctl(ppp_dev_fd, PPPIOCNEWUNIT, &ifunit);
 	}
+	if (x < 0 && errno == EEXIST) {
+		srand(time(NULL) * getpid());
+		ifunit = rand() % 10000;
+		x = ioctl(ppp_dev_fd, PPPIOCNEWUNIT, &ifunit);
+	}
 	if (x < 0)
 		error("Couldn't create new ppp unit: %m");
 


### PR DESCRIPTION
Linux kernel has nasty bug / feature. If PPPIOCNEWUNIT is called with
negative ppp unit id (which is default option when command line argument
"unit" is not specified; and tells kernel to choose some free ppp unit id)
and the lowest unused/free ppp unit id is present in some existing network
interface name prefixed by "ppp" string then this PPPIOCNEWUNIT ioctl
fails. In this case kernel is basically unable to create a new ppp
interface via PPPIOCNEWUNIT ioctl when user does not specify some unused
and non-conflicted unit id.

Linux kernel should be fixed to choose usable ppp unit id when was
requested via PPPIOCNEWUNIT parameter -1.

Until this happen add a workaround for pppd to help choosing some random
ppp unit id when kernel returns this error.

Simple test case (run on system when there is no ppp interface):

    sudo ./pppd ifname ppp1 nodefaultroute noauth nolock local nodetach pty "./pppd nodefaultroute noauth nolock local nodetach notty"

Second pppd process without this patch prints into syslog following error:

    pppd 2.4.10-dev started by pali, uid 0
    Couldn't create new ppp unit: File exists
    Exit.

With this patch it choose fallbacks to random ppp unit id and success:

    pppd 2.4.10-dev started by pali, uid 0
    Using interface ppp1361
    Connect: ppp1361 <--> /dev/pts/14
    ...