### PR TITLE
CI: Updated the Solaris GitHub action to use macOS 12

### DIFF
--- a/.github/workflows/solaris.yaml
+++ b/.github/workflows/solaris.yaml
@@ -3,12 +3,12 @@ on: [push, pull_request]
 
 jobs:
   solaris:
-    runs-on: macos-10.15
+    runs-on: macos-12
     steps:
     - name: Checkout PPP sources
       uses: actions/checkout@v2
     - name: Build
-      uses: vmactions/solaris-vm@v0.0.4
+      uses: vmactions/solaris-vm@v0
       with:
         run: |
           pkg update


### PR DESCRIPTION
GitHub says that macOS 10.15 support will be removed at the end of the month (see https://github.com/actions/virtual-environments/issues/5583), so this update is needed.
~~Sadly, the build time seems to be twice longer...~~ No, it's the same than before.