### PR TITLE
pppd: Fix compilation on Linux when IPV6 is disabled

### DIFF
--- a/pppd/sys-linux.c
+++ b/pppd/sys-linux.c
@@ -128,8 +128,6 @@
 
 #include <linux/ppp-ioctl.h>
 
-
-#ifdef PPP_WITH_IPV6CP
 #include <linux/netlink.h>
 #include <linux/rtnetlink.h>
 #include <linux/if_link.h>
@@ -140,7 +138,6 @@
 #define RTM_NEWSTATS 92
 #define RTM_GETSTATS 94
 #define IFLA_STATS_LINK_64 1
-#endif /* PPP_WITH_IPV6CP */
 
 #include <linux/if_addr.h>
 /* glibc versions prior to 2.24 do not define SOL_NETLINK */
@@ -157,7 +154,10 @@
 #include "pppd.h"
 #include "fsm.h"
 #include "ipcp.h"
+
+#ifdef PPP_WITH_IPV6CP
 #include "eui64.h"
+#endif /* PPP_WITH_IPV6CP */
 
 #ifdef PPP_WITH_FILTER
 #include <pcap-bpf.h>


### PR DESCRIPTION
This rearranges the PPP_WITH_IPV6CP guards added in commit
80b8744eb42c ("Changing INET6 to PPP_WITH_IPV6CP and adding configure
option", 2021-08-06) so that we (a) always include the rtnetlink
headers, since we need them for get_ppp_stats_rtnetlink(), and (b)
don't include eui64.h unless we have IPV6 support.

Fixes: 80b8744eb42c ("Changing INET6 to PPP_WITH_IPV6CP and adding configure option")
Signed-off-by: Paul Mackerras <paulus@ozlabs.org>