### PR TITLE
Add option to show all options (show-options)

### DIFF
--- a/pppd/main.c
+++ b/pppd/main.c
@@ -364,6 +364,11 @@ main(int argc, char *argv[])
     if (debug)
 	setlogmask(LOG_UPTO(LOG_DEBUG));
 
+    if (show_options) {
+	showopts();
+	die(0);
+    }
+
     /*
      * Check that we are running as root.
      */

--- a/pppd/pppd.h
+++ b/pppd/pppd.h
@@ -358,6 +358,7 @@ extern bool	multilink;	/* enable multilink operation */
 extern bool	noendpoint;	/* don't send or accept endpt. discrim. */
 extern char	*bundle_name;	/* bundle name for multilink */
 extern bool	dump_options;	/* print out option values */
+extern bool	show_options;	/* show all option names and descriptions */
 extern bool	dryrun;		/* check everything, print options, exit */
 extern int	child_wait;	/* # seconds to wait for children at end */
 
@@ -776,7 +777,8 @@ int  override_value(char *, int, const char *);
 				/* override value if permitted by priority */
 void print_options(printer_func, void *);
 				/* print out values of all options */
-
+void showopts(void);
+                /* show all option names and description */
 int parse_dotted_ip(char *, u_int32_t *);
 
 /*


### PR DESCRIPTION
Fixes issue #251 by introducing a new option to print all supported options.

This also fixes up the show version function to include copyright and package name from autotools. Also supports "-v", a short hand version for --version.

Signed-off-by: Eivind Næss <eivnaes@yahoo.com>