### PR TITLE
Fix libsystemd detection

### DIFF
--- a/.github/workflows/ubuntu.yaml
+++ b/.github/workflows/ubuntu.yaml
@@ -5,13 +5,17 @@ jobs:
   build_and_test:
     runs-on: ubuntu-latest
     env:
-      configure_flags: --enable-ipxcp --enable-multilink
+      configure_flags: --enable-ipxcp --enable-multilink --enable-systemd
 
     steps:
     - uses: actions/checkout@v2
 
     - name: install required packages
-      run: sudo DEBIAN_FRONTEND=noninteractive apt-get -y -qq install build-essential autoconf automake pkg-config libtool m4 autoconf-archive libssl-dev libatm1-dev libpcap-dev
+      run: |
+        sudo DEBIAN_FRONTEND=noninteractive apt-get -y -qq update
+        sudo DEBIAN_FRONTEND=noninteractive apt-get -y -qq install \
+          build-essential autoconf automake pkg-config libtool m4 autoconf-archive \
+          libssl-dev libatm1-dev libpcap-dev libsystemd-dev
 
     - name: configure
       run: ./autogen.sh ${{ env.configure_flags }}

--- a/configure.ac
+++ b/configure.ac
@@ -106,7 +106,7 @@ AM_CONDITIONAL(WITH_SYSTEMD, test "x${enable_systemd}" = "xyes")
 AM_COND_IF([WITH_SYSTEMD],
     AC_DEFINE([SYSTEMD], 1, [Enable support for systemd notifications]))
 AS_IF([test "x${enable_systemd}" = "xyes"], [
-	PKG_CHECK_MODULES([systemd], [systemd])])
+	PKG_CHECK_MODULES([SYSTEMD], [libsystemd])])
 
 #
 # Enable Callback Protocol Support, disabled by default


### PR DESCRIPTION
1. Use uppercase for `prefix` parameter
  `SYSTEMD_CFLAGS` is used elsewhere so `prefix` cannot be lowercase.
  https://autotools.info/pkgconfig/pkg_check_modules.html

2. The module name should be `libsystemd`
   Previously it will result in the following compile error when building pppd/auth.c:
   > /usr/bin/ld: pppd-auth.o: undefined reference to symbol 'sd_notify@@LIBSYSTEMD_209'
   > /usr/bin/ld: /usr/lib/libsystemd.so.0: error adding symbols: DSO missing from command line

   This is due to missing `-lsystemd-daemon` flag which is provided by `libsystemd-daemon-devel` package on Debian or `systemd-libs` on ArchLinux. And the proper .pc file in the package is `libsystemd` not `systemd`.
   https://stackoverflow.com/a/38303241