### PR TITLE
pppd: add noresolvconf option

### DIFF
--- a/pppd/ipcp.c
+++ b/pppd/ipcp.c
@@ -93,6 +93,7 @@ struct notifier *ip_down_notifier = NULL;
 static int default_route_set[NUM_PPP];	/* Have set up a default route */
 static int proxy_arp_set[NUM_PPP];	/* Have created proxy arp entry */
 static bool usepeerdns;			/* Ask peer for DNS addrs */
+static bool resolvconf = 1;		/* deploy peer DNS addrs */
 static bool usepeerwins;		/* Ask peer for WINS addrs */
 static int ipcp_is_up;			/* have called np_up() */
 static int ipcp_is_open;		/* haven't called np_finished() */
@@ -221,6 +222,8 @@ static option_t ipcp_option_list[] = {
 
     { "usepeerdns", o_bool, &usepeerdns,
       "Ask peer for DNS address(es)", 1 },
+    { "noresolvconf", o_bool, &resolvconf,
+      "Ask for DNS but Don't deploy resolv.conf", OPT_A2CLR},
 
     { "usepeerwins", o_bool, &usepeerwins,
       "Ask peer for WINS address(es)", 1 },
@@ -1846,7 +1849,8 @@ ipcp_up(fsm *f)
 	script_setenv("DNS2", ip_ntoa(go->dnsaddr[1]), 0);
     if (usepeerdns && (go->dnsaddr[0] || go->dnsaddr[1])) {
 	script_setenv("USEPEERDNS", "1", 0);
-	create_resolv(go->dnsaddr[0], go->dnsaddr[1]);
+	if (resolvconf)
+	    create_resolv(go->dnsaddr[0], go->dnsaddr[1]);
     }
 
     if (go->winsaddr[0])

--- a/pppd/pppd.8
+++ b/pppd/pppd.8
@@ -1190,7 +1190,10 @@ by the peer (if any) are passed to the /etc/ppp/ip\-up script in the
 environment variables DNS1 and DNS2, and the environment variable
 USEPEERDNS will be set to 1.  In addition, pppd will create an
 /etc/ppp/resolv.conf file containing one or two nameserver lines with
-the address(es) supplied by the peer.
+the address(es) supplied by the peer, unless \fBresolvconf\fB is turned off.
+.TP
+.B noresolvconf
+Do not create /etc/ppp/resolv.conf with the DNS server addresses supplied by the peer.
 .TP
 .B usepeerwins
 Ask the peer for up to 2 WINS server addresses.  The addresses supplied


### PR DESCRIPTION
On embedded systems, it is easier to avoid the resolv.conf conflicts than to fix them.
'noresolvconf' option on top of 'usepeerdns' lets pppd request DNS information and forward the info to the scripts, but will not write resolv.conf. The ip-up/ip-down scripts can then deal with the info and no conflict ever existed.

Signed-off-by: Kurt Van Dijck <dev.kurt@vandijck-laurijssen.be>