### PR TITLE
pppd: Fix spurious LCP echo failures with lcp-echo-adaptive option

### DIFF
--- a/pppd/lcp.c
+++ b/pppd/lcp.c
@@ -2279,6 +2279,8 @@ LcpSendEchoRequest (fsm *f)
 
 	if (get_ppp_stats(f->unit, &cur_stats) && cur_stats.pkts_in != last_pkts_in) {
 	    last_pkts_in = cur_stats.pkts_in;
+	    /* receipt of traffic indicates the link is working... */
+	    lcp_echos_pending = 0;
 	    return;
 	}
     }


### PR DESCRIPTION
If the lcp-echo-adaptive option is specified, it means that seeing received traffic on the link is considered to be an indication that the link is working.  Hence, this resets the count of missing LCP echo-replies to 0 when traffic is seen.  Without this, occasional echo failures interspersed with link traffic can accumulate and end up causing a disconnection even when the link is working correctly.

Signed-off-by: Paul Mackerras <paulus@ozlabs.org>