### PR TITLE
radius: distinguish between User-Request and Admin-Reset.

### DIFF
--- a/pppd/plugins/radius/radius.c
+++ b/pppd/plugins/radius/radius.c
@@ -1051,8 +1051,11 @@ radius_acct_stop(void)
     av_type = PW_NAS_ERROR;
     switch( status ) {
 	case EXIT_OK:
-	case EXIT_USER_REQUEST:
 	    av_type = PW_USER_REQUEST;
+	    break;
+
+	case EXIT_USER_REQUEST:
+	    av_type = PW_ADMIN_RESET;
 	    break;
 
 	case EXIT_HANGUP:


### PR DESCRIPTION
For the purposes of our definition:

User-Request - remote side hanging up.
Admin-Reset - local side hanging up.

Reasoning is that typically radius will be used to authentication dial-in users, so if the pppd gets killed locally, that's not the User (client) requesting hangup, but rather the local administrator (be that a manual kill, or as a result of a CoA/Disconnect).

Signed-off-by: Jaco Kroon <jaco@uls.co.za>