### PR TITLE
Should check name, not ifname in ppp_set_ifname

### DIFF
--- a/pppd/main.c
+++ b/pppd/main.c
@@ -313,7 +313,7 @@ int ppp_get_ifname(char *buf, size_t bufsz)
 
 void ppp_set_ifname(const char *name)
 {
-    if (ifname) {
+    if (name) {
         strlcpy(ifname, name, sizeof(ifname));
     }
 }


### PR DESCRIPTION
This surfaces in discussion of issue #389 