### PR TITLE
Removes autotools include guards for stdbool.h and friends

### DIFF
--- a/pppd/cbcp.h
+++ b/pppd/cbcp.h
@@ -30,10 +30,14 @@
  * AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING
  * OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
-#ifndef CBCP_H
-#define CBCP_H
+#ifndef PPP_CBCP_H
+#define PPP_CBCP_H
 
 #include "pppdconf.h"
+
+#ifdef  __cplusplus
+extern "C" {
+#endif
 
 typedef struct cbcp_state {
     int    us_unit;	/* Interface unit number */
@@ -57,4 +61,9 @@ extern struct protent cbcp_protent;
 #define CB_CONF_USER   2
 #define CB_CONF_ADMIN  3
 #define CB_CONF_LIST   4
+
+#ifdef __cplusplus
+}
 #endif
+
+#endif // PPP_CBCP_H

--- a/pppd/ccp.h
+++ b/pppd/ccp.h
@@ -34,6 +34,10 @@
 
 #include "pppdconf.h"
 
+#ifdef  __cplusplus
+extern "C" {
+#endif
+
 typedef struct ccp_options {
     bool bsd_compress;		/* do BSD Compress? */
     bool deflate;		/* do Deflate? */
@@ -55,4 +59,8 @@ extern ccp_options ccp_hisoptions[];
 
 extern struct protent ccp_protent;
 
+#ifdef __cplusplus
+}
 #endif
+
+#endif // PPP_CCP_H

--- a/pppd/chap.h
+++ b/pppd/chap.h
@@ -33,6 +33,10 @@
 
 #include "pppdconf.h"
 
+#ifdef  __cplusplus
+extern "C" {
+#endif
+
 /*
  * CHAP packets begin with a standard header with code, id, len (2 bytes).
  */
@@ -165,4 +169,8 @@ extern void chap_auth_with_peer(int unit, char *our_name, int digest_code);
 /* Represents the CHAP protocol to the main pppd code */
 extern struct protent chap_protent;
 
+#ifdef  __cplusplus
+}
 #endif
+
+#endif // PPP_CHAP_NEW_H

--- a/pppd/chap_ms.h
+++ b/pppd/chap_ms.h
@@ -35,6 +35,10 @@
 
 #include "pppdconf.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define MAX_NT_PASSWORD		256	/* Max (Unicode) chars in an NT pass */
 
 #define MS_CHAP_RESPONSE_LEN	49	/* Response length for MS-CHAP */
@@ -94,5 +98,9 @@ void GenerateAuthenticatorResponse(unsigned char *PasswordHashHash,
 			unsigned char *authResponse);
 
 void chapms_init(void);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* PPP_CHAPMS_H */

--- a/pppd/crypto.h
+++ b/pppd/crypto.h
@@ -30,6 +30,10 @@
 #ifndef PPP_CRYPTO_H
 #define PPP_CRYPTO_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #ifndef MD5_DIGEST_LENGTH
 #define MD5_DIGEST_LENGTH 16
 #endif
@@ -152,4 +156,8 @@ int PPP_crypto_init();
  */
 int PPP_crypto_deinit();
 
+#ifdef __cplusplus
+}
 #endif
+
+#endif // PPP_CRYPTO_H

--- a/pppd/crypto_ms.h
+++ b/pppd/crypto_ms.h
@@ -36,6 +36,10 @@
 
 #include "pppdconf.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * This is the DES encrypt functions as described by RFC2759.
  * 
@@ -71,5 +75,9 @@ int DesEncrypt(const unsigned char *clear, const unsigned char *key,
  */
 int DesDecrypt(const unsigned char *cipher, const unsigned char *key,
         unsigned char *clear);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* PPP_PPPCRYPT_H */

--- a/pppd/ecp.h
+++ b/pppd/ecp.h
@@ -35,6 +35,10 @@
 
 #include "pppdconf.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #ifndef PPP_ECP
 #define PPP_ECP 0x8053
 #endif
@@ -53,4 +57,8 @@ extern ecp_options ecp_hisoptions[];
 
 extern struct protent ecp_protent;
 
+#ifdef __cplusplus
+}
 #endif
+
+#endif	// PPP_ECP_H

--- a/pppd/eui64.h
+++ b/pppd/eui64.h
@@ -38,6 +38,10 @@
 
 #include "pppdconf.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #if defined(SOL2)
 #include <netinet/in.h>
 
@@ -105,5 +109,9 @@ typedef union
 #define eui64_setlo32(e, l)	eui64_set32(e, l)
 
 char *eui64_ntoa(eui64_t);	/* Returns ascii representation of id */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* PPP_EUI64_H */

--- a/pppd/fsm.h
+++ b/pppd/fsm.h
@@ -46,11 +46,14 @@
 
 #include "pppdconf.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /*
  * Packet header = Code, id, length.
  */
 #define HEADERLEN	4
-
 
 /*
  *  CP (LCP, IPCP, etc.) codes.
@@ -163,4 +166,8 @@ void fsm_sdata (fsm *, int, int, unsigned char *, int);
  */
 extern int peer_mru[];		/* currently negotiated peer MRU (per unit) */
 
+#ifdef __cplusplus
+}
 #endif
+
+#endif // PPP_FSM_H

--- a/pppd/ipcp.h
+++ b/pppd/ipcp.h
@@ -44,6 +44,10 @@
 
 #include "pppdconf.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /*
  * Options.
  */
@@ -117,5 +121,9 @@ extern ip_down_hook_fn *ip_down_hook;
  */
 typedef void (ip_choose_hook_fn)(uint32_t *);
 extern ip_choose_hook_fn *ip_choose_hook;
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* PPP_IPCP_H */

--- a/pppd/ipv6cp.h
+++ b/pppd/ipv6cp.h
@@ -39,6 +39,10 @@
 
 #include "pppdconf.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /*  Original version, based on RFC2023 :
 
     Copyright (c) 1995, 1996, 1997 Francis.Dupont@inria.fr, INRIA Rocquencourt,
@@ -185,5 +189,9 @@ extern ipv6_up_hook_fn *ipv6_up_hook;
  */
 typedef void (ipv6_down_hook_fn)(void);
 extern ipv6_down_hook_fn *ipv6_down_hook;
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/pppd/lcp.h
+++ b/pppd/lcp.h
@@ -44,6 +44,11 @@
 
 #include "pppdconf.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
 /*
  * Options.
  */
@@ -144,4 +149,9 @@ extern struct protent lcp_protent;
    before deciding the link is looped-back. */
 #define DEFLOOPBACKFAIL	10
 
+
+#ifdef __cplusplus
+}
 #endif
+
+#endif // PPP_LCP_H

--- a/pppd/magic.h
+++ b/pppd/magic.h
@@ -44,10 +44,18 @@
 
 #include "pppdconf.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 void magic_init (void);	/* Initialize the magic number generator */
 u_int32_t magic (void);	/* Returns the next magic number */
 
 /* Fill buffer with random bytes */
 void random_bytes (unsigned char *buf, int len);
 
+#ifdef __cplusplus
+}
 #endif
+
+#endif // PPP_MAGIC_H

--- a/pppd/mppe.h
+++ b/pppd/mppe.h
@@ -37,6 +37,11 @@
 
 #include "pppdconf.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
 #define MPPE_PAD		4	/* MPPE growth per frame */
 #define MPPE_MAX_KEY_SIZE	32	/* Largest key length */
 #define MPPE_MAX_KEY_LEN       16      /* Largest key size accepted by the kernel */
@@ -175,4 +180,9 @@ void mppe_set_chapv2(unsigned char *PasswordHashHash,
 		    unsigned char *NTResponse, int IsServer);
 
 #endif  // #ifdef PPP_WITH_MPPE
+
+#ifdef __cplusplus
+}
+#endif
+
 #endif  // #ifdef PPP_MPPE_H

--- a/pppd/multilink.h
+++ b/pppd/multilink.h
@@ -33,6 +33,10 @@
 
 #include "pppdconf.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /*
  * values for epdisc.class
  */
@@ -109,4 +113,9 @@ static inline bool mp_master() {
 }
 
 #endif // PPP_WITH_MULTILINK
+
+#ifdef __cplusplus
+}
+#endif
+
 #endif // PPP_MULTILINK_H

--- a/pppd/options.h
+++ b/pppd/options.h
@@ -31,6 +31,10 @@
 #ifndef PPP_OPTIONS_H
 #define PPP_OPTIONS_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 enum opt_type {
 	o_special_noarg,
 	o_special,
@@ -111,4 +115,9 @@ int ppp_int_option(char *name, int *value);
 /* Print an error message about an option */
 void ppp_option_error(char *fmt, ...);
 
+
+#ifdef __cplusplus
+}
 #endif
+
+#endif // PPP_OPTIONS_H

--- a/pppd/pppd.h
+++ b/pppd/pppd.h
@@ -51,6 +51,10 @@
 
 #include "pppdconf.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /*
  * Limits
  */
@@ -559,5 +563,9 @@ extern int (*holdoff_hook)(void);
 extern int  (*allowed_address_hook)(uint32_t addr);
 extern void (*snoop_recv_hook)(unsigned char *p, int len);
 extern void (*snoop_send_hook)(unsigned char *p, int len);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* PPP_PPPD_H */

--- a/pppd/pppd.h
+++ b/pppd/pppd.h
@@ -43,25 +43,11 @@
 #ifndef PPP_PPPD_H
 #define PPP_PPPD_H
 
-#ifdef HAVE_STDARG_H
 #include <stdarg.h>
-#endif
-
-#ifdef HAVE_STDBOOL_H
 #include <stdbool.h>
-#endif
-
-#ifdef HAVE_STDDEF_H
 #include <stddef.h>
-#endif
-
-#ifdef HAVE_STDINT_H
 #include <stdint.h>
-#endif
-
-#ifdef HAVE_SYS_TYPES_H
 #include <sys/types.h>
-#endif
 
 #include "pppdconf.h"
 

--- a/pppd/session.h
+++ b/pppd/session.h
@@ -32,6 +32,10 @@
 
 #include "pppdconf.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define SESS_AUTH  1	/* Check User Authentication */
 #define SESS_ACCT  2	/* Check Account Validity */
 
@@ -88,5 +92,9 @@ session_start(const int flags, const char* user, const char* passwd, const char*
  */
 void
 session_end(const char* tty);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif // PPP_SESSION_H

--- a/pppd/upap.h
+++ b/pppd/upap.h
@@ -44,6 +44,11 @@
 
 #include "pppdconf.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
 /*
  * Packet header = Code, id, length.
  */
@@ -143,5 +148,9 @@ extern pap_logout_hook_fn *pap_logout_hook;
  * as a client
  */
 extern pap_passwd_hook_fn *pap_passwd_hook;
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif // PPP_UPAP_H


### PR DESCRIPTION
Closes issue #402

Two commits that does the following: 
- Remove autotools defines wrapping standard header files in pppd/pppd.h, especially stdbool.h
- Adds extern "C" declarations to header files