### PR TITLE
Fix for issue #405, this adds a --with-system-ca-path to configure script

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -222,6 +222,28 @@ AS_IF([test -n "$with_logfile_dir"],
 AC_SUBST(PPPD_LOGFILE_DIR)
 
 #
+# System CA certificates path
+AC_ARG_WITH(system-ca-path,
+    AS_HELP_STRING([--with-system-ca-path=/path/to/ssl/certs], [path to system CA certificates]),
+    [
+       case "$withval" in
+       "" | y | ye | yes)
+            with_system_ca_path="${sysconfdir}/ssl/certs"
+            ;;
+       n | no)
+            ;;
+       *)
+            with_system_ca_path="$withval"
+            ;;
+       esac
+    ],[with_system_ca_path="${sysconfdir}/ssl/certs"])
+AM_CONDITIONAL(PPP_WITH_SYSTEM_CA_PATH, [test "$with_system_ca_path" != "no"])
+AM_COND_IF(PPP_WITH_SYSTEM_CA_PATH, [
+    SYSTEM_CA_PATH="$with_system_ca_path"
+])
+AC_SUBST(SYSTEM_CA_PATH)
+
+#
 # Check for OpenSSL
 AX_CHECK_OPENSSL
 AM_CONDITIONAL(PPP_WITH_OPENSSL, test "x${with_openssl}" != "xno")
@@ -390,6 +412,7 @@ $PACKAGE_NAME version $PACKAGE_VERSION
     Runtime Dir..........: $PPPD_RUNTIME_DIR
     Logfile Dir..........: $PPPD_LOGFILE_DIR
     Plugin Dir...........: $PPPD_PLUGIN_DIR
+    System CA Path ......: ${SYSTEM_CA_PATH:-not set}
     With OpenSSL.........: ${with_openssl:-yes}
     With libatm..........: ${with_atm:-no}
     With libpam..........: ${with_pam:-no}

--- a/pppd/Makefile.am
+++ b/pppd/Makefile.am
@@ -87,6 +87,10 @@ pppd_CPPFLAGS = -DSYSCONFDIR=\"${sysconfdir}\" -DLOCALSTATEDIR=\"${localstatedir
 pppd_LDFLAGS =
 pppd_LIBS =
 
+if PPP_WITH_SYSTEM_CA_PATH
+pppd_CPPFLAGS += -DSYSTEM_CA_PATH='"@SYSTEM_CA_PATH@"'
+endif
+
 if LINUX
 pppd_SOURCES += sys-linux.c
 noinst_HEADERS += termios_linux.h

--- a/pppd/auth.c
+++ b/pppd/auth.c
@@ -1334,6 +1334,13 @@ auth_check_options(void)
     if (user[0] == 0 && !explicit_user)
 	strlcpy(user, our_name, sizeof(user));
 
+#if defined(SYSTEM_CA_PATH) && (defined(PPP_WITH_EAPTLS) || defined(PPP_WITH_PEAP))
+    /* Use system default for CA Path if not specified */
+    if (!ca_path) {
+        ca_path = SYSTEM_CA_PATH;
+    }
+#endif
+
     /*
      * If we have a default route, require the peer to authenticate
      * unless the noauth option was given or the real user is root.


### PR DESCRIPTION
It allows package maintainers to set the default location for the ca directory.