### PR TITLE
Fixing buffer overflow issue in chat.c

### DIFF
--- a/chat/chat.c
+++ b/chat/chat.c
@@ -1336,10 +1336,10 @@ int get_string(register char *string)
     char temp[STR_LEN];
     int c, printed = 0, len, minlen;
     register char *s = temp, *end = s + STR_LEN;
-    char *logged = temp;
+    char *s1, *logged = temp;
 
     fail_reason = (char *)0;
-    string = clean(string, 0);
+    string = s1 = clean(string, 0);
     len = strlen(string);
     minlen = (len > sizeof(fail_buffer)? len: sizeof(fail_buffer)) - 1;
 
@@ -1349,12 +1349,14 @@ int get_string(register char *string)
     if (len > STR_LEN) {
 	msgf("expect string is too long");
 	exit_code = 1;
+	free(s1);
 	return 0;
     }
 
     if (len == 0) {
 	if (verbose)
 	    msgf("got it");
+	free(s1);
 	return (1);
     }
 
@@ -1402,6 +1404,7 @@ int get_string(register char *string)
 		    strftime (report_buffer, 20, "%b %d %H:%M:%S ", tm_now);
 		    strcat (report_buffer, report_string[n]);
 
+		    free(report_string[n]);
 		    report_string[n] = (char *) NULL;
 		    report_gathering = 1;
 		    break;
@@ -1433,6 +1436,7 @@ int get_string(register char *string)
 
 	    alarm(0);
 	    alarmed = 0;
+	    free(s1);
 	    return (1);
 	}
 
@@ -1449,6 +1453,7 @@ int get_string(register char *string)
 		alarmed = 0;
 		exit_code = n + 4;
 		strcpy(fail_reason = fail_buffer, abort_string[n]);
+		free(s1);
 		return (0);
 	    }
 	}
@@ -1480,6 +1485,7 @@ int get_string(register char *string)
 
     exit_code = 3;
     alarmed   = 0;
+    free(s1);
     return (0);
 }
 

--- a/chat/chat.c
+++ b/chat/chat.c
@@ -182,7 +182,7 @@ int n_aborts = 0, abort_next = 0, timeout_next = 0, echo_next = 0;
 int clear_abort_next = 0;
 
 char *report_string[MAX_REPORTS] ;
-char  report_buffer[256] ;
+char  report_buffer[4096] ;
 int n_reports = 0, report_next = 0, report_gathering = 0 ; 
 int clear_report_next = 0;
 
@@ -1411,8 +1411,10 @@ int get_string(register char *string)
 	else {
 	    if (!iscntrl (c)) {
 		int rep_len = strlen (report_buffer);
-		report_buffer[rep_len]     = c;
-		report_buffer[rep_len + 1] = '\0';
+		if ((rep_len + 1) < sizeof(report_buffer)) {
+		    report_buffer[rep_len]     = c;
+		    report_buffer[rep_len + 1] = '\0';
+		}
 	    }
 	    else {
 		report_gathering = 0;


### PR DESCRIPTION
There was two issues here, the report_buffer is too small to hold the value, and accessing the memory outside its bounds. The following fixes was made:
- Expand the size of report_buffer to 4096 from 256, this is to account for handling of really long GSM USSD report strings
- Make sure to not to access memory outside the bounds of the bufffer