### PR TITLE
Move pppgetpass.8 to EXTRA_DIST

### DIFF
--- a/contrib/pppgetpass/Makefile.am
+++ b/contrib/pppgetpass/Makefile.am
@@ -1,5 +1,4 @@
 noinst_PROGRAMS = pppgetpass.vt
-noinst_man8_MANS = pppgetpass.8
 
 pppgetpass_vt_SOURCES = pppgetpass.vt.c
 pppgetpass_vt_CPPFLAGS = -Wno-unused-result
@@ -14,4 +13,5 @@ pppgetpass_gtk_LDADD = $(GLIB_LIBS) $(GTK_LIBS)
 endif
 
 EXTRA_DIST = \
-    pppgetpass.sh
+    pppgetpass.sh \
+    pppgetpass.8


### PR DESCRIPTION
automake does not seem to include noinst_*_MANS in the dist tarball.