### PR TITLE
create new function "PPPOECloseDiscoverySock", and close DiscoverySock after "the_channel->establish_ppp"

### DIFF
--- a/pppd/auth.c
+++ b/pppd/auth.c
@@ -663,6 +663,8 @@ void start_link(int unit)
 	goto disconnect;
     }
 
+    the_channel->close_discovery_sock();
+
     if (!demand && ifunit >= 0)
 	set_ifunit(1);
 

--- a/pppd/plugins/pppoe/discovery.c
+++ b/pppd/plugins/pppoe/discovery.c
@@ -727,8 +727,6 @@ discovery2(PPPoEConnection *conn)
     }
 
     /* We're done. */
-    close(conn->discoverySocket);
-    conn->discoverySocket = -1;
     conn->discoveryState = STATE_SESSION;
     return;
 }

--- a/pppd/plugins/pppoe/plugin.c
+++ b/pppd/plugins/pppoe/plugin.c
@@ -332,6 +332,25 @@ PPPOEDeviceOptions(void)
 	}
 }
 
+/**********************************************************************
+ * %FUNCTION: PPPOECloseDiscoverySock
+ * %ARGUMENTS:
+ * None
+ * %RETURNS:
+ * Nothing
+ * %DESCRIPTION:
+ * Close discoverySocket
+ ***********************************************************************/
+static void
+PPPOECloseDiscoverySock(void)
+{
+  if (conn->discoverySocket > 0) {
+    close(conn->discoverySocket);
+    conn->discoverySocket = -1;
+    conn->discoveryState = STATE_SESSION;
+  }
+}
+
 struct channel pppoe_channel;
 
 /**********************************************************************
@@ -480,6 +499,7 @@ struct channel pppoe_channel = {
     .disestablish_ppp = &ppp_generic_disestablish,
     .send_config = NULL,
     .recv_config = &PPPOERecvConfig,
+    .close_discovery_sock = &PPPOECloseDiscoverySock,
     .close = NULL,
     .cleanup = NULL
 };

--- a/pppd/pppd.h
+++ b/pppd/pppd.h
@@ -235,6 +235,8 @@ struct channel {
 	void (*send_config)(int, uint32_t, int, int);
 	/* set the receive-side PPP parameters of the channel */
 	void (*recv_config)(int, uint32_t, int, int);
+	/* close discovery sock */
+	void (*close_discovery_sock)(void);
 	/* cleanup on error or normal exit */
 	void (*cleanup)(void);
 	/* close the device, called in children after fork */


### PR DESCRIPTION
Before doing add_fd(ppp_dev_fd) (line 698) in sys-linux.c after PADS, LCP: Conf-Request from the PPP server arrives first and times out. To address this, I moved the close discoverySock() after the cut-off of DiscoverySock by the_channel->establish_ppp to improve the processing.