### PR TITLE
Implement logging the LCP RTT

### DIFF
--- a/pppd/pppd.8
+++ b/pppd/pppd.8
@@ -637,6 +637,10 @@ Set the maximum number of LCP terminate-request transmissions to
 Set the LCP restart interval (retransmission timeout) to \fIn\fR
 seconds (default 3).
 .TP
+.B lcp\-rtt\-file \fIfilename
+Sets the file where the round-trip time (RTT) of LCP echo-request frames
+will be logged.
+.TP
 .B linkname \fIname\fR
 Sets the logical name of the link to \fIname\fR.  Pppd will create a
 file named \fBppp\-\fIname\fB.pid\fR in /var/run (or /etc/ppp on some

--- a/scripts/lcp_rtt_dump
+++ b/scripts/lcp_rtt_dump
@@ -1,0 +1,81 @@
+#!/usr/bin/perl
+# vim: shiftwidth=4 tabstop=4
+#
+# This program dumps to standard output the content of the file written
+# by pppd's lcp-rtt-file configuration option.
+#
+# Copyright (C) Marco d'Itri <md@linux.it>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+
+use v5.14;
+use warnings;
+use autodie;
+
+use POSIX qw(strftime);
+
+{
+	my $data = read_data($ARGV[0] || '/run/ppp-rtt.data');
+	die "The data file is invalid!\n" if not $data;
+	dump_data($data);
+}
+
+sub dump_data {
+	my ($s) = @_;
+
+	say "status:   $s->{status}";
+	say "interval: $s->{echo_interval}";
+	say "position: $s->{position}";
+	say 'elements: ' . scalar(@{ $s->{data} });
+	say '';
+
+	foreach (my $i= 0; $i < @{ $s->{data} }; $i++) {
+		my $date = strftime('%F %T', localtime($s->{data}->[$i]->[0]));
+		print "$i\t$date\t$s->{data}->[$i]->[1]\t$s->{data}->[$i]->[2]\n";
+	}
+}
+
+sub read_data {
+	my ($file) = @_;
+
+	my $data;
+	open(my $fh, '<', $file);
+	binmode($fh);
+	my $bytes_read;
+	do {
+		$bytes_read = sysread($fh, $data, 8192, length($data));
+	} while ($bytes_read == 8192);
+	close($fh);
+
+	my ($magic, $status, $position, $echo_interval, $rest)
+		= unpack('NNNN a*', $data);
+	return undef if $magic != 0x19450425;
+
+	# the position is relative to the C array, not to the logical entries
+	$position /= 2;
+
+	my @rawdata = unpack('(N C a3)*', $rest);
+	my @data;
+	while (my ($time, $loss, $rtt) = splice(@rawdata, 0, 3)) {
+		push(@data, [ $time, unpack('N', "\000$rtt"), $loss ]);
+	}
+
+	if (0) {
+	@data =
+		# skip any "empty" (null) entries
+		grep { $_->[0] }
+		# rearrange the list in chronological order
+		(@data[$position+1 .. $#data], @data[0 .. $position]);
+	}
+
+	return {
+		status			=> $status,
+		echo_interval	=> $echo_interval,
+		position 		=> $position,
+		data			=> \@data,
+	};
+}
+

--- a/scripts/lcp_rtt_exporter
+++ b/scripts/lcp_rtt_exporter
@@ -1,0 +1,108 @@
+#!/usr/bin/perl
+# vim: shiftwidth=4 tabstop=4
+#
+# This CGI program is a Prometheus exporter for pppd's lcp-rtt-file feature.
+#
+# Copyright (C) Marco d'Itri <md@linux.it>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+
+use v5.14;
+use warnings;
+use autodie;
+
+use List::Util qw(sum max min);
+
+{
+	my $data = read_data('/run/ppp-rtt.data');
+	my $stats = compute_statistics($data, 60);
+
+	my $s = metrics($stats);
+
+	print "Content-type: text/plain\n\n$s";
+	exit;
+}
+
+sub metrics {
+	my ($stats) = @_;
+
+	my $s = <<END;
+# TYPE lcp_rtt_status gauge
+# HELP LCP RTT status
+lcp_rtt_status $stats->{status}
+END
+	foreach (qw(average min max loss)) {
+		next if not exists $stats->{$_};
+		$s .= <<END;
+# TYPE lcp_rtt_$_ gauge
+# HELP LCP RTT $_
+lcp_rtt_$_ $stats->{$_}
+END
+	}
+
+	return $s;
+}
+
+sub compute_statistics {
+	my ($data, $length) = @_;
+
+	my $cutoff = time() - $length;
+	my @e = grep { $_->[0] >= $cutoff } @{ $data->{data} };
+	return { status => -1 } if not @e; # no data
+
+	my $average = (sum map { $_->[1] } @e) / scalar(@e);
+	my $min = min map { $_->[1] } @e;
+	my $max = max map { $_->[1] } @e;
+	my $loss = sum map { $_->[2] } @e;
+
+	return {
+		status	=> $data->{status},
+		average	=> $average,
+		min		=> $min,
+		max		=> $max,
+		loss	=> $loss,
+	};
+}
+
+sub read_data {
+	my ($file) = @_;
+
+	my $data;
+	open(my $fh, '<', $file);
+	binmode($fh);
+	my $bytes_read;
+	do {
+		$bytes_read = sysread($fh, $data, 8192, length($data));
+	} while ($bytes_read == 8192);
+	close($fh);
+
+	my ($magic, $status, $position, $echo_interval, $rest)
+		= unpack('NNNN a*', $data);
+	return undef if $magic != 0x19450425;
+
+	# the position is relative to the C array, not to the logical entries
+	$position /= 2;
+
+	my @rawdata = unpack('(N C a3)*', $rest);
+	my @data;
+	while (my ($time, $loss, $rtt) = splice(@rawdata, 0, 3)) {
+		push(@data, [ $time, unpack('N', "\000$rtt"), $loss ]);
+	}
+
+	@data =
+		# skip any "empty" (null) entries
+		grep { $_->[0] }
+		# rearrange the list in chronological order
+		(@data[$position+1 .. $#data], @data[0 .. $position]);
+
+	return {
+		status			=> $status,
+		echo_interval	=> $echo_interval,
+		position 		=> $position,
+		data			=> \@data,
+	};
+}
+


### PR DESCRIPTION
This patch adds the lcp-rtt-file configuration option, which instructs pppd to add a timestamp to the data section of each LCP echo request frame and then log their round trip time and any detected packet loss to a circular buffer in that file.

Other programs then can asynchronously read the file and report statistics about the line.

I have also added examples of a simple program which dumps the content of the log file and a Prometheus exporter which can be run as a CGI.

This feature was inspired by a similar one in a commercial PPP implementation, but I have never actually seen that and I do not know how it actually works or it was implemented.

Signed-off-by: Marco d'Itri <md@linux.it>