### PR TITLE
Fixes issue #429, stray include of an openssl header was removed

### DIFF
--- a/pppd/crypto_ms.c
+++ b/pppd/crypto_ms.c
@@ -122,8 +122,6 @@ MakeKey(const unsigned char *key, unsigned char *des_key)
 	DES_set_odd_parity((DES_cblock *)des_key);
 }
 
-#include <openssl/evp.h>
-
 int
 DesEncrypt(const unsigned char *clear, const unsigned char *key, unsigned char *cipher)
 {


### PR DESCRIPTION
Must have been something I forgot to remove when I was working on this code. After this change, you pppd compiles without openssl as long as you add the following to the configure script: ./configure --disable-peap --disable-eaptls --without-openssl