### PR TITLE
Make lock dir configurable

### DIFF
--- a/pppd/Makefile.am
+++ b/pppd/Makefile.am
@@ -83,7 +83,7 @@ pppd_SOURCES = \
     upap.c \
     utils.c
 
-pppd_CPPFLAGS = -DSYSCONFDIR=\"${sysconfdir}\" -DLOCALSTATEDIR=\"${localstatedir}\" -DPPPD_RUNTIME_DIR='"@PPPD_RUNTIME_DIR@"' -DPPPD_LOGFILE_DIR='"@PPPD_LOGFILE_DIR@"'
+pppd_CPPFLAGS = -DSYSCONFDIR=\"${sysconfdir}\" -DPPPD_RUNTIME_DIR='"@PPPD_RUNTIME_DIR@"' -DPPPD_LOGFILE_DIR='"@PPPD_LOGFILE_DIR@"'
 pppd_LDFLAGS =
 pppd_LIBS =
 

--- a/pppd/pathnames.h
+++ b/pppd/pathnames.h
@@ -120,12 +120,12 @@
 #define PPP_PATH_PPPDB          PPP_PATH_VARRUN  "/pppd2.tdb"
 
 #ifdef __linux__
-#define PPP_PATH_LOCKDIR        PPP_PATH_VARRUN  "/lock"
+#define PPP_PATH_LOCKDIR        "/var/lock"
 #else
 #ifdef SVR4
-#define PPP_PATH_LOCKDIR        LOCALSTATEDIR "/spool/locks"
+#define PPP_PATH_LOCKDIR        "/var/spool/locks"
 #else
-#define PPP_PATH_LOCKDIR        LOCALSTATEDIR "/spool/lock"
+#define PPP_PATH_LOCKDIR        "/var/spool/lock"
 #endif
 #endif
 


### PR DESCRIPTION
lock dir changed on linux from /var/lock to /run/pppd/lock with pppd-2.5.0, which makes pppd fail to start if the distribution does not pre-create the directory.

This reverts it back to /var/lock.
    

~~In the line of configurability, also make the lock dir configurable through ./configure --with-lock-dir for distributions that prefer /run/pppd/lock, but change the default for linux back to /var/lock~~

~~This commit is bigger than it should be, because the current configure mechanism for PPPD_RUNTIME_DIR and others is inconditional: pathnames.h has #else cases for when the variable is not defined but that is not possible.~~
~~This does not work for lock dir, because on non-linux platform the path is different, and reproducing this logic at configure time is not trivial.~~

~~Instead of the current method, only set the the PPPD_X_DIR variables in pppdconf.h if it was explicitly set in configure, and otherwise leave it to the else case.~~

~~Note:~~
- ~~the else cases were incorrect for runtime dir and log dirs, and have been fixed~~
- ~~PPPD_PLUGIN_DIR has been kept as is because it is used for rpath in makefiles and needs to be set inconditionnaly at configure time~~



Fixes: 66a8c74c3f73 ("Let ./configure control the paths for pppd")
Fixes: #419