### PR TITLE
pppd/options.c: fix memory leak or error path

### DIFF
--- a/pppd/options.c
+++ b/pppd/options.c
@@ -601,6 +601,7 @@ ppp_options_from_file(char *filename, int must_exist, int check_prot, int priv)
 
 err:
     fclose(f);
+    free(option_source);
     privileged_option = oldpriv;
     option_source = oldsource;
     return ret;


### PR DESCRIPTION
found by Coverity

```
602err:
603    fclose(f);
604    privileged_option = oldpriv;
   CID 436193 (#1 of 1): Resource leak (RESOURCE_LEAK)10. overwrite_var: Overwriting option_source in option_source = oldsource leaks the storage that option_source points to.
605    option_source = oldsource;
```