### PR TITLE
pppd/options.c: fix memory leak on error path (#441)

### DIFF
--- a/pppd/options.c
+++ b/pppd/options.c
@@ -1802,6 +1802,7 @@ loadplugin(char **argv)
     (*init)();
     if (path != arg)
 	free(path);
+	dlclose(handle);
     return 1;
 
  errclose:


### PR DESCRIPTION
found by Coverity

1803    if (path != arg)
1804        free(path);

    CID 436214 (#1 of 1): Resource leak (RESOURCE_LEAK)
    12. leaked_storage: Variable handle going out of scope leaks the
	storage it points to.
	1805    return 1;