### PR TITLE
Fix for #446, don't crash on too long of a device name

### DIFF
--- a/pppd/plugins/pppoe/if.c
+++ b/pppd/plugins/pppoe/if.c
@@ -175,7 +175,7 @@ openInterface(char const *ifname, UINT16_t type, unsigned char *hwaddr)
     sa.sll_ifindex = ifr.ifr_ifindex;
 
 #else
-    strcpy(sa.sa_data, ifname);
+    strlcpy(sa.sa_data, ifname, sizeof(sa.sa_data));
 #endif
 
     /* We're only interested in packets on specified interface */
@@ -212,7 +212,7 @@ sendPacket(PPPoEConnection *conn, int sock, PPPoEPacket *pkt, int size)
 #else
     struct sockaddr sa;
 
-    strcpy(sa.sa_data, conn->ifName);
+    strlcpy(sa.sa_data, conn->ifName, sizeof(sa.sa_data));
     err = sendto(sock, pkt, size, 0, &sa, sizeof(sa));
 #endif
     if (err < 0) {


### PR DESCRIPTION
This change will fix the crash that happens in issue #446 

However, it is worth noting that the device name is typically limited by the struct ifr, and the size of the ifr.ifr_name field (15). It's just that when it is used in context of the sockaddr structure, it's being limited to 14 bytes. The origin of this is the "device name" option which is capped at a really large value. Should probably be set to 14??