### PR TITLE
Escape all minus characters in the man pages

### DIFF
--- a/pppd/plugins/pppoe/pppoe-discovery.8
+++ b/pppd/plugins/pppoe/pppoe-discovery.8
@@ -83,4 +83,4 @@ version number and usage information, then exit.
 \fBpppoe\-discovery\fR was written by Marco d'Itri <md@linux.it>,
 based on \fBpppoe\fR by Dianne Skoll <dianne@skoll.ca>.
 .SH SEE ALSO
-pppoe(8), pppoe-sniff(8)
+pppoe(8), pppoe\-sniff(8)

--- a/pppd/plugins/radius/pppd-radattr.8
+++ b/pppd/plugins/radius/pppd-radattr.8
@@ -24,7 +24,7 @@ where
 .I pppN
 is the name of the PPP interface.  The RADIUS attributes are stored
 one per line in the format "Attribute-Name Attribute-Value".  This
-format is convenient for use in /etc/ppp/ip-up and /etc/ppp/ip-down
+format is convenient for use in /etc/ppp/ip\-up and /etc/ppp/ip\-down
 scripts.
 .LP
 Note that you
@@ -38,7 +38,7 @@ To use the plugin, simply supply the
 options to pppd.
 
 .SH SEE ALSO
-.BR pppd (8) " pppd-radius" (8)
+.BR pppd (8) " pppd\-radius" (8)
 
 .SH AUTHOR
 Dianne Skoll <dianne@skoll.ca>

--- a/pppd/plugins/radius/pppd-radius.8
+++ b/pppd/plugins/radius/pppd-radius.8
@@ -19,9 +19,9 @@ plugin radius.so
 .LP
 The RADIUS plugin for pppd permits pppd to perform PAP, CHAP, MS-CHAP and
 MS-CHAPv2 authentication against a RADIUS server instead of the usual
-.I /etc/ppp/pap-secrets
+.I /etc/ppp/pap\-secrets
 and
-.I /etc/ppp/chap-secrets
+.I /etc/ppp/chap\-secrets
 files.
 .LP
 The RADIUS plugin is built on a library called
@@ -33,7 +33,7 @@ plugin
 .SH OPTIONS
 The RADIUS plugin introduces one additional pppd option:
 .TP
-.BI "radius-config-file " filename
+.BI "radius\-config\-file " filename
 The file
 .I filename
 is taken as the radiusclient configuration file.  If this option is not
@@ -44,10 +44,10 @@ as the configuration file.
 .BI "avpair " attribute=value
 Adds an Attribute-Value pair to be passed on to the RADIUS server on each request.
 .TP
-.BI map-to-ifname
+.BI map\-to\-ifname
 Sets Radius NAS-Port attribute to number equal to interface name (Default)
 .TP
-.BI map-to-ttyname
+.BI map\-to\-ttyname
 Sets Radius NAS-Port attribute value via libradiusclient library
 
 .SH USAGE
@@ -61,7 +61,7 @@ RADIUS server should assign an IP address to the peer using the RADIUS
 Framed-IP-Address attribute.
 
 .SH SEE ALSO
-.BR pppd (8) " pppd-radattr" (8)
+.BR pppd (8) " pppd\-radattr" (8)
 
 .SH AUTHOR
 Dianne Skoll <dianne@skoll.ca>

--- a/pppd/pppd.8
+++ b/pppd/pppd.8
@@ -687,7 +687,7 @@ network control protocol comes up).
 Terminate after \fIn\fR consecutive failed connection attempts.  A
 value of 0 means no limit.  The default value is 10.
 .TP
-.B max-tls-version \fIstring
+.B max\-tls-\version \fIstring
 (EAP-TLS, or PEAP) Configures the max allowed TLS version used during
 negotiation with a peer.  The default value for this is \fI1.2\fR.  Values
 allowed for this option is \fI1.0.\fR, \fI1.1\fR, \fI1.2\fR, \fI1.3\fR.
@@ -760,7 +760,7 @@ name to \fIname\fR.)
 Disable Address/Control compression in both directions (send and
 receive).
 .TP
-.B need-peer-eap
+.B need\-peer\-eap
 (EAP-TLS) Require the peer to verify our authentication credentials.
 .TP
 .B noauth
@@ -1136,13 +1136,13 @@ The device used by pppd with this option must have sync support.
 Currently supports Microgate SyncLink adapters
 under Linux and FreeBSD 2.2.8 and later.
 .TP
-.B tls-verify-method \fIstring
+.B tls\-verify\-method \fIstring
 (EAP-TLS, or PEAP) Match the value specified for \fIremotename\fR to that that
 of the X509 certificates subject name, common name, or suffix of the common
 name.  Respective values allowed for this option is: \fInone\fR, \fIsubject\fR,
 \fIname\fR, or \fIsuffix\fR.  The default value for this option is \fIname\fR.
 .TP
-.B tls-verify-key-usage
+.B tls\-verify\-key\-usage
 (EAP-TLS, or PEAP) Enables examination of peer certificate's purpose, and
 extended key usage attributes.
 .TP
@@ -1233,36 +1233,36 @@ by specifying ppp'd option \fBnic-eth0\fR. Prefix \fBnic-\fR for this
 option may be avoided if interface name is unambiguous and does not
 look like any other pppd's option.
 .TP
-.B pppoe-service \fIname
+.B pppoe\-service \fIname
 Connect to specified PPPoE service name. For backward compatibility also
 \fBrp_pppoe_service\fP option name is supported.
 .TP
-.B pppoe-ac \fIname
+.B pppoe\-ac \fIname
 Connect to specified PPPoE access concentrator name. For backward
 compatibility also \fBrp_pppoe_ac\fP option name is supported.
 .TP
-.B pppoe-sess \fIsessid\fP:\fImacaddr
+.B pppoe\-sess \fIsessid\fP:\fImacaddr
 Attach to existing PPPoE session. For backward compatibility also
 \fBrp_pppoe_sess\fP option name is supported.
 .TP
-.B pppoe-verbose \fIn
+.B pppoe\-verbose \fIn
 Be verbose about discovered access concentrators. When set to 2 or bigger
 value then dump also discovery packets. For backward compatibility also
 \fBrp_pppoe_verbose\fP option name is supported.
 .TP
-.B pppoe-mac \fImacaddr
+.B pppoe\-mac \fImacaddr
 Connect to specified MAC address.
 .TP
-.B pppoe-host-uniq \fIstring
+.B pppoe\-host\-uniq \fIstring
 Set the PPPoE Host-Uniq tag to the supplied hex string.
 By default PPPoE Host-Uniq tag is set to the pppd's process PID.
 For backward compatibility this option may be specified without
 \fBpppoe-\fP prefix.
 .TP
-.B pppoe-padi-timeout \fIn
+.B pppoe\-padi\-timeout \fIn
 Initial timeout for discovery packets in seconds (default 5).
 .TP
-.B pppoe-padi-attempts \fIn
+.B pppoe\-padi\-attempts \fIn
 Number of discovery attempts (default 3).
 .SH OPTIONS FILES
 Options can be taken from files as well as the command line.  Pppd
@@ -1729,7 +1729,7 @@ We failed to authenticate ourselves to the peer.
 Pppd invokes scripts at various stages in its processing which can be
 used to perform site-specific ancillary processing.  These scripts are
 usually shell scripts, but could be executable code files instead.
-Pppd does not wait for the scripts to finish (except for the ip-pre-up
+Pppd does not wait for the scripts to finish (except for the ip\-pre\-up
 script).  The scripts are
 executed as root (with the real and effective user-id set to 0), so
 that they can do things such as update routing tables or run
@@ -2075,7 +2075,7 @@ are met:
 .br
      (412) 268-4387, fax: (412) 268-7395
 .br
-     tech-transfer@andrew.cmu.edu
+     tech\-transfer@andrew.cmu.edu
 .LP
 3b. The name(s) of the authors of this software must not be used to
    endorse or promote products derived from this software without


### PR DESCRIPTION
From man-pages(7):

   Where a real minus character is required (e.g., for numbers such as -1,
   for man page cross references such as utf-8(7), or when writing options
   that  have a leading dash, such as in ls -l), use the following form in
   the man page source:

       \-