### PR TITLE
pppd: constify log format strings.

### DIFF
--- a/pppd/main.c
+++ b/pppd/main.c
@@ -2150,7 +2150,7 @@ notify(struct notifier *notif, int val)
  * novm - log an error message saying we ran out of memory, and die.
  */
 void
-novm(char *msg)
+novm(const char *msg)
 {
     fatal("Virtual memory exhausted allocating %s\n", msg);
 }

--- a/pppd/plugins/pppoe/pppoe-discovery.c
+++ b/pppd/plugins/pppoe/pppoe-discovery.c
@@ -33,7 +33,7 @@ int pppoe_verbose;
 static FILE *debugFile;
 
 void
-fatal(char *fmt, ...)
+fatal(const char *fmt, ...)
 {
     va_list pvar;
     va_start(pvar, fmt);
@@ -44,7 +44,7 @@ fatal(char *fmt, ...)
 }
 
 void
-error(char *fmt, ...)
+error(const char *fmt, ...)
 {
     va_list pvar;
     va_start(pvar, fmt);
@@ -54,7 +54,7 @@ error(char *fmt, ...)
 }
 
 void
-warn(char *fmt, ...)
+warn(const char *fmt, ...)
 {
     va_list pvar;
     va_start(pvar, fmt);
@@ -64,7 +64,7 @@ warn(char *fmt, ...)
 }
 
 void
-info(char *fmt, ...)
+info(const char *fmt, ...)
 {
     va_list pvar;
     va_start(pvar, fmt);

--- a/pppd/pppd.h
+++ b/pppd/pppd.h
@@ -252,10 +252,10 @@ extern struct channel *the_channel;
 bool debug_on();
 
 /* Safe sprintf++ */
-int slprintf(char *, int, char *, ...);		
+int slprintf(char *, int, const char *, ...);
 
 /* vsprintf++ */
-int vslprintf(char *, int, char *, va_list);
+int vslprintf(char *, int, const char *, va_list);
 
 /* safe strcpy */
 size_t strlcpy(char *, const char *, size_t);
@@ -264,25 +264,25 @@ size_t strlcpy(char *, const char *, size_t);
 size_t strlcat(char *, const char *, size_t);
 
 /* log a debug message */
-void dbglog(char *, ...);
+void dbglog(const char *, ...);
 
 /* log an informational message */
-void info(char *, ...);
+void info(const char *, ...);
 
 /* log a notice-level message */
-void notice(char *, ...);
+void notice(const char *, ...);
 
 /* log a warning message */
-void warn(char *, ...);
+void warn(const char *, ...);
 
 /* log an error message */
-void error(char *, ...);	
+void error(const char *, ...);
 
 /* log an error message and die(1) */
-void fatal(char *, ...);	
+void fatal(const char *, ...);
 
 /* Say we ran out of memory, and die */
-void novm(char *);
+void novm(const char *);
 
 /* Format a packet and log it with syslog */
 void log_packet(unsigned char *, int, char *, int);

--- a/pppd/utils.c
+++ b/pppd/utils.c
@@ -68,7 +68,7 @@
 extern char *strerror();
 #endif
 
-static void logit(int, char *, va_list);
+static void logit(int, const char *, va_list);
 static void log_write(int, char *);
 static void vslp_printer(void *, char *, ...);
 static void format_packet(u_char *, int, printer_func, void *);
@@ -120,7 +120,7 @@ strlcat(char *dest, const char *src, size_t len)
  * Returns the number of chars put into buf.
  */
 int
-slprintf(char *buf, int buflen, char *fmt, ...)
+slprintf(char *buf, int buflen, const char *fmt, ...)
 {
     va_list args;
     int n;
@@ -137,14 +137,15 @@ slprintf(char *buf, int buflen, char *fmt, ...)
 #define OUTCHAR(c)	(buflen > 0? (--buflen, *buf++ = (c)): 0)
 
 int
-vslprintf(char *buf, int buflen, char *fmt, va_list args)
+vslprintf(char *buf, int buflen, const char *fmt, va_list args)
 {
     int c, i, n;
     int width, prec, fillch;
     int base, len, neg, quoted;
     long lval = 0;
     unsigned long val = 0;
-    char *str, *f, *buf0;
+    char *str, *buf0;
+    const char *f;
     unsigned char *p;
     char num[32];
     time_t t;
@@ -600,7 +601,7 @@ print_string(char *p, int len, printer_func printer, void *arg)
  * logit - does the hard work for fatal et al.
  */
 static void
-logit(int level, char *fmt, va_list args)
+logit(int level, const char *fmt, va_list args)
 {
     char buf[1024];
 
@@ -635,7 +636,7 @@ log_write(int level, char *buf)
  * fatal - log an error message and die horribly.
  */
 void
-fatal(char *fmt, ...)
+fatal(const char *fmt, ...)
 {
     va_list pvar;
 
@@ -655,7 +656,7 @@ fatal(char *fmt, ...)
  * error - log an error message.
  */
 void
-error(char *fmt, ...)
+error(const char *fmt, ...)
 {
     va_list pvar;
 
@@ -670,7 +671,7 @@ error(char *fmt, ...)
  * warn - log a warning message.
  */
 void
-warn(char *fmt, ...)
+warn(const char *fmt, ...)
 {
     va_list pvar;
 
@@ -684,7 +685,7 @@ warn(char *fmt, ...)
  * notice - log a notice-level message.
  */
 void
-notice(char *fmt, ...)
+notice(const char *fmt, ...)
 {
     va_list pvar;
 
@@ -698,7 +699,7 @@ notice(char *fmt, ...)
  * info - log an informational message.
  */
 void
-info(char *fmt, ...)
+info(const char *fmt, ...)
 {
     va_list pvar;
 
@@ -712,7 +713,7 @@ info(char *fmt, ...)
  * dbglog - log a debug message.
  */
 void
-dbglog(char *fmt, ...)
+dbglog(const char *fmt, ...)
 {
     va_list pvar;
 


### PR DESCRIPTION
Found when trying to do a simple dbglog(__FUNCTION__);