### PR TITLE
CI: Fixed the Solaris build.

### DIFF
--- a/.github/workflows/solaris.yaml
+++ b/.github/workflows/solaris.yaml
@@ -3,12 +3,12 @@ on: [push, pull_request]
 
 jobs:
   solaris:
-    runs-on: macos-12
+    runs-on: ubuntu-22.04
     steps:
     - name: Checkout PPP sources
       uses: actions/checkout@v3
     - name: Build
-      uses: vmactions/solaris-vm@v0
+      uses: vmactions/solaris-vm@v1.0.0
       with:
         run: |
           pkg update


### PR DESCRIPTION
Switched to the latest version of the Solaris GitHub Action that now uses Qemu and libvirt on an Ubuntu runner instead of VirtualBox on a macOS runner.