### PR TITLE
Fixing a problem where the detection of openssl failed on solaris

### DIFF
--- a/m4/ax_check_openssl.m4
+++ b/m4/ax_check_openssl.m4
@@ -68,7 +68,7 @@ AC_DEFUN([AX_CHECK_OPENSSL], [
         fi
     ])
 
-    AS_IF([test "${with_openssl}" != "no" && test ! ${found}], [
+    AS_IF([test "${with_openssl}" != "no" && test "${found}" != "true"], [
         OPENSSL_INCLUDES=
         for ssldir in $ssldirs; do
             AC_MSG_CHECKING([for openssl/ssl.h in $ssldir])
@@ -84,7 +84,7 @@ AC_DEFUN([AX_CHECK_OPENSSL], [
             ])
         done])
 
-    AS_IF([test "${with_openssl}" != "no" && test ${found}], [
+    AS_IF([test "${with_openssl}" != "no" && test "${found}" = "true" ], [
 
         # try the preprocessor and linker with our new flags,
         # being careful not to pollute the global LIBS, LDFLAGS, and CPPFLAGS


### PR DESCRIPTION
Quick and dirty fix to resolve issue in compiling on Solaris fails.

There might be a longer more exhaustive fixed needed here. This is because Solaris 11.4 has two versions of openssl installed. The default one is 

library/security/openssl
library/security/openssl-11

They are both installed (by default I think), and the 1.0.2 version is compiled to use for application with FIPS certification requirements. We should probably link to the newer one openssl-11, but the paths aren't setup correctly for this, e.g. /usr/include/openssl points to /usr/openssl/default/include via symlink by default. 

Users on Solaris 11.4 should be aware that the way to configure this using the openssl-11 libraries would be to pass the correct 
`--with-openssl=/usr/openssl/1.1` to the configure (or autogen.sh) command.