### PR TITLE
pppoe: Fix sending of PADT on connection termination

### DIFF
--- a/pppd/plugins/pppoe/plugin.c
+++ b/pppd/plugins/pppoe/plugin.c
@@ -310,6 +310,9 @@ PPPOEDisconnectDevice(void)
 		sizeof(struct sockaddr_pppox)) < 0 && errno != EALREADY)
 	error("Failed to disconnect PPPoE socket: %d %m", errno);
     close(conn->sessionSocket);
+    if (conn->discoverySocket < 0)
+	conn->discoverySocket =
+            openInterface(conn->ifName, Eth_PPPOE_Discovery, NULL);
     if (conn->discoverySocket >= 0) {
         sendPADT(conn, NULL);
 	close(conn->discoverySocket);


### PR DESCRIPTION
Commit 2b4166d02ed0 ("Close discovery socket after session completed", 2020-11-26) arranged for the discovery socket to be closed when the PPPOE session negotiation was complete.  However, the discovery socket is used for sending a PADT message when the connection terminates, and now that doesn't work because the socket has been closed.

To fix this, we reopen the discovery socket in order to send the PADT message.