### PR TITLE
CI: Used a Solaris VM with all needed build tools preinstalled.

### DIFF
--- a/.github/workflows/solaris.yaml
+++ b/.github/workflows/solaris.yaml
@@ -8,11 +8,10 @@ jobs:
     - name: Checkout PPP sources
       uses: actions/checkout@v3
     - name: Build
-      uses: vmactions/solaris-vm@v1.0.0
+      uses: vmactions/solaris-vm@v1.0.2
       with:
+        release: "11.4-gcc"
         run: |
-          pkg update
-          pkg install gcc automake autoconf libtool
           ./autogen.sh CFLAGS="-Wno-deprecated-declarations"
           make
           make install


### PR DESCRIPTION
This avoids loosing time updating the package cache and installing the needed packages.

This also avoids breaking the Solaris build if the Solaris mirrors are temporarily unavailable.