### PR TITLE
CI: Updated the 'checkout' actions that were using Node.js 16 to Node.js 20.

### DIFF
--- a/.github/workflows/solaris.yaml
+++ b/.github/workflows/solaris.yaml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - name: Checkout PPP sources
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Build
       uses: vmactions/solaris-vm@v1.0.2
       with:

--- a/.github/workflows/ubuntu.yaml
+++ b/.github/workflows/ubuntu.yaml
@@ -8,7 +8,7 @@ jobs:
       configure_flags: --enable-multilink --enable-systemd --enable-cbcp
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: install required packages
       run: |
@@ -37,7 +37,7 @@ jobs:
       LDFLAGS: '-fsanitize=address'
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: install required packages
       run: |


### PR DESCRIPTION
Node.js 16 actions will be deprecated in Spring 2024, see https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20.