### PR TITLE
Exit early if we strlen on an empty string

### DIFF
--- a/pppd/auth.c
+++ b/pppd/auth.c
@@ -2164,6 +2164,8 @@ auth_number(void)
     while (wp) {
 	/* trailing '*' wildcard */
 	l = strlen(wp->word);
+	if (l == 0)
+	    return 1;
 	if ((wp->word)[l - 1] == '*')
 	    l--;
 	if (!strncasecmp(wp->word, remote_number, l))


### PR DESCRIPTION
In the event we do strlen on an empty string, we should bail.