### PR TITLE
fix reliability of print_link_stats (with option persist)

### DIFF
--- a/pppd/ipcp.c
+++ b/pppd/ipcp.c
@@ -2026,7 +2026,7 @@ ipcp_down(fsm *f)
     sifvjcomp(f->unit, 0, 0, 0);
 
     print_link_stats(); /* _after_ running the notifiers and ip_down_hook(),
-			 * because print_link_stats() sets link_stats_valid
+			 * because print_link_stats() sets link_stats_print
 			 * to 0 (zero) */
 
     /*

--- a/pppd/main.c
+++ b/pppd/main.c
@@ -1331,9 +1331,9 @@ print_link_stats(void)
 void
 reset_link_stats(int u)
 {
-    if (!get_ppp_stats(u, &old_link_stats))
-	return;
+    get_ppp_stats(u, &old_link_stats);
     ppp_get_time(&start_time);
+    link_stats_print = 1;
 }
 
 /*


### PR DESCRIPTION
* pppd/ipcp.c: (ipcp_down): fix comment
* pppd/main.c: (reset_link_stats): reset print_link_stats to 1, set start_time even if get_ppp_stats fails.