### PR TITLE
pppd: Add ip-pre-up-script option

### DIFF
--- a/pppd/ipcp.c
+++ b/pppd/ipcp.c
@@ -1766,7 +1766,7 @@ ip_demand_conf(int u)
     }
     if (!sifaddr(u, wo->ouraddr, wo->hisaddr, GetMask(wo->ouraddr)))
 	return 0;
-    ipcp_script(PPP_PATH_IPPREUP, 1);
+    ipcp_script(path_ippreup, 1);
     if (!sifup(u))
 	return 0;
     if (!sifnpmode(u, PPP_IP, NPMODE_QUEUE))
@@ -1932,7 +1932,7 @@ ipcp_up(fsm *f)
 	ifindex = if_nametoindex(ifname);
 
 	/* run the pre-up script, if any, and wait for it to finish */
-	ipcp_script(PPP_PATH_IPPREUP, 1);
+	ipcp_script(path_ippreup, 1);
 
 	/* check if preup script renamed the interface */
 	if (!if_indextoname(ifindex, ifname)) {

--- a/pppd/main.c
+++ b/pppd/main.c
@@ -367,6 +367,7 @@ main(int argc, char *argv[])
 
     strlcpy(path_ipup, PPP_PATH_IPUP, MAXPATHLEN);
     strlcpy(path_ipdown, PPP_PATH_IPDOWN, MAXPATHLEN);
+    strlcpy(path_ippreup, PPP_PATH_IPPREUP, MAXPATHLEN);
 
 #ifdef PPP_WITH_IPV6CP
     strlcpy(path_ipv6up, PPP_PATH_IPV6UP, MAXPATHLEN);

--- a/pppd/options.c
+++ b/pppd/options.c
@@ -123,6 +123,7 @@ int	connect_delay = 1000;	/* wait this many ms after connect script */
 int	req_unit = -1;		/* requested interface unit */
 char	path_ipup[MAXPATHLEN];	/* pathname of ip-up script */
 char	path_ipdown[MAXPATHLEN];/* pathname of ip-down script */
+char	path_ippreup[MAXPATHLEN]; /* pathname of ip-pre-up script */
 char	req_ifname[IFNAMSIZ];	/* requested interface name */
 bool	multilink = 0;		/* Enable multilink operation */
 char	*bundle_name = NULL;	/* bundle name for multilink */
@@ -336,6 +337,9 @@ struct option general_options[] = {
       OPT_PRIV|OPT_STATIC, NULL, MAXPATHLEN },
     { "ip-down-script", o_string, path_ipdown,
       "Set pathname of ip-down script",
+      OPT_PRIV|OPT_STATIC, NULL, MAXPATHLEN },
+    { "ip-pre-up-script", o_string, path_ippreup,
+      "Set pathname of ip-pre-up script",
       OPT_PRIV|OPT_STATIC, NULL, MAXPATHLEN },
 
 #ifdef PPP_WITH_IPV6CP

--- a/pppd/pppd-private.h
+++ b/pppd/pppd-private.h
@@ -194,6 +194,7 @@ extern int	max_data_rate;	/* max bytes/sec through charshunt */
 extern int	req_unit;	/* interface unit number to use */
 extern char	path_ipup[]; 	/* pathname of ip-up script */
 extern char	path_ipdown[];	/* pathname of ip-down script */
+extern char	path_ippreup[];	/* pathname of ip-pre-up script */
 extern char	req_ifname[]; /* interface name to use (IFNAMSIZ) */
 extern bool	multilink;	/* enable multilink operation (options.c) */
 extern bool	noendpoint;	/* don't send or accept endpt. discrim. */


### PR DESCRIPTION
This option allow a user to specify the path to the script usually located at /etc/ppp/ip-pre-up, similarly to the existing ip-up-script and ip-down-script options.