### PR TITLE
pppd: Add ipv6-pre-up-script option

### DIFF
--- a/pppd/ipv6cp.c
+++ b/pppd/ipv6cp.c
@@ -322,7 +322,7 @@ struct protent ipv6cp_protent = {
 };
 
 static void ipv6cp_clear_addrs (int, eui64_t, eui64_t);
-static void ipv6cp_script (char *);
+static void ipv6cp_script (char *, int);
 static void ipv6cp_script_done (void *);
 
 /*
@@ -1235,6 +1235,7 @@ ipv6_demand_conf(int u)
 	eui64_magic_nz(wo->ourid);
     }
 
+    ipv6cp_script(path_ipv6preup, 1);
     if (!sif6up(u))
 	return 0;
     if (!sif6addr(u, wo->ourid, wo->hisid))
@@ -1342,6 +1343,9 @@ ipv6cp_up(fsm *f)
 	sifnpmode(f->unit, PPP_IPV6, NPMODE_PASS);
 
     } else {
+	/* run the pre-up script, if any, and wait for it to finish */
+	ipv6cp_script(path_ipv6preup, 1);
+
 	/* bring the interface up for IPv6 */
 	if (!sif6up(f->unit)) {
 	    if (debug)
@@ -1381,7 +1385,7 @@ ipv6cp_up(fsm *f)
      */
     if (ipv6cp_script_state == s_down && ipv6cp_script_pid == 0) {
 	ipv6cp_script_state = s_up;
-	ipv6cp_script(path_ipv6up);
+	ipv6cp_script(path_ipv6up, 0);
     }
 }
 
@@ -1432,7 +1436,7 @@ ipv6cp_down(fsm *f)
     /* Execute the ipv6-down script */
     if (ipv6cp_script_state == s_up && ipv6cp_script_pid == 0) {
 	ipv6cp_script_state = s_down;
-	ipv6cp_script(path_ipv6down);
+	ipv6cp_script(path_ipv6down, 0);
     }
 }
 
@@ -1470,13 +1474,13 @@ ipv6cp_script_done(void *arg)
     case s_up:
 	if (ipv6cp_fsm[0].state != OPENED) {
 	    ipv6cp_script_state = s_down;
-	    ipv6cp_script(path_ipv6down);
+	    ipv6cp_script(path_ipv6down, 0);
 	}
 	break;
     case s_down:
 	if (ipv6cp_fsm[0].state == OPENED) {
 	    ipv6cp_script_state = s_up;
-	    ipv6cp_script(path_ipv6up);
+	    ipv6cp_script(path_ipv6up, 0);
 	}
 	break;
     }
@@ -1488,7 +1492,7 @@ ipv6cp_script_done(void *arg)
  * interface-name tty-name speed local-LL remote-LL.
  */
 static void
-ipv6cp_script(char *script)
+ipv6cp_script(char *script, int wait)
 {
     char strspeed[32], strlocal[64], strremote[64];
     char *argv[8];
@@ -1506,7 +1510,10 @@ ipv6cp_script(char *script)
     argv[6] = ipparam;
     argv[7] = NULL;
 
-    ipv6cp_script_pid = run_program(script, argv, 0, ipv6cp_script_done,
+    if (wait)
+      run_program(script, argv, 0, NULL, NULL, 1);
+    else
+      ipv6cp_script_pid = run_program(script, argv, 0, ipv6cp_script_done,
 				    NULL, 0);
 }
 

--- a/pppd/main.c
+++ b/pppd/main.c
@@ -371,6 +371,7 @@ main(int argc, char *argv[])
 #ifdef PPP_WITH_IPV6CP
     strlcpy(path_ipv6up, PPP_PATH_IPV6UP, MAXPATHLEN);
     strlcpy(path_ipv6down, PPP_PATH_IPV6DOWN, MAXPATHLEN);
+    strlcpy(path_ipv6preup, PPP_PATH_IPV6PREUP, MAXPATHLEN);
 #endif
     link_stats_valid = 0;
     link_stats_print = 1;

--- a/pppd/options.c
+++ b/pppd/options.c
@@ -137,6 +137,7 @@ int	dfl_route_metric = -1;	/* metric of the default route to set over the PPP li
 #ifdef PPP_WITH_IPV6CP
 char	path_ipv6up[MAXPATHLEN];   /* pathname of ipv6-up script */
 char	path_ipv6down[MAXPATHLEN]; /* pathname of ipv6-down script */
+char	path_ipv6preup[MAXPATHLEN]; /* pathname of ipv6-pre-up script */
 #endif
 
 unsigned int  maxoctets = 0;    /* default - no limit */
@@ -344,6 +345,9 @@ struct option general_options[] = {
       OPT_PRIV|OPT_STATIC, NULL, MAXPATHLEN },
     { "ipv6-down-script", o_string, path_ipv6down,
       "Set pathname of ipv6-down script",
+      OPT_PRIV|OPT_STATIC, NULL, MAXPATHLEN },
+    { "ipv6-pre-up-script", o_string, path_ipv6preup,
+      "Set pathname of ipv6-pre-up script",
       OPT_PRIV|OPT_STATIC, NULL, MAXPATHLEN },
 #endif
 

--- a/pppd/pathnames.h
+++ b/pppd/pathnames.h
@@ -119,6 +119,7 @@
 #ifdef PPP_WITH_IPV6CP
 #define PPP_PATH_IPV6UP         PPP_PATH_CONFDIR "/ipv6-up"
 #define PPP_PATH_IPV6DOWN       PPP_PATH_CONFDIR "/ipv6-down"
+#define PPP_PATH_IPV6PREUP      PPP_PATH_CONFDIR "/ipv6-pre-up"
 #endif
 
 #define PPP_PATH_PPPDB          PPP_PATH_VARRUN  "/pppd2.tdb"

--- a/pppd/pppd-private.h
+++ b/pppd/pppd-private.h
@@ -210,6 +210,7 @@ extern int  option_priority;    /* priority of current options */
 #ifdef PPP_WITH_IPV6CP
 extern char	path_ipv6up[]; /* pathname of ipv6-up script */
 extern char	path_ipv6down[]; /* pathname of ipv6-down script */
+extern char	path_ipv6preup[]; /* pathname of ipv6-pre-up script */
 #endif
 
 #if defined(PPP_WITH_EAPTLS) || defined(PPP_WITH_PEAP)

--- a/pppd/pppd.8
+++ b/pppd/pppd.8
@@ -524,8 +524,8 @@ seconds (default 3).
 .TP
 .B ipparam \fIstring
 Provides an extra parameter most of the notification scripts, most notably
-ip\-up, ip\-pre\-up, ip\-down, ipv6\-up, ipv6\-down, auth\-up and auth\-down
-scripts.  If this
+ip\-up, ip\-pre\-up, ip\-down, ipv6\-up, ipv6\-pre\-up, ipv6\-down,
+auth\-up and auth\-down scripts.  If this
 option is given, the \fIstring\fR supplied is given as the 6th
 parameter to those scripts.
 .TP
@@ -1740,7 +1740,7 @@ Pppd invokes scripts at various stages in its processing which can be
 used to perform site-specific ancillary processing.  These scripts are
 usually shell scripts, but could be executable code files instead.
 Pppd does not wait for the scripts to finish (except for the net\-init,
-net\-pre\-up and ip\-pre\-up scripts).  The scripts are
+net\-pre\-up, ip\-pre\-up and ipv6\-pre\-up scripts).  The scripts are
 executed as root (with the real and effective user-id set to 0), so
 that they can do things such as update routing tables or run
 privileged daemons.  Be careful that the contents of these scripts do
@@ -1879,6 +1879,14 @@ used for undoing the effects of the /etc/ppp/ip\-up and
 /etc/ppp/ip\-pre\-up scripts.  It is
 invoked in the same manner and with the same parameters as the ip\-up
 script.
+.TP
+.B /etc/ppp/ipv6\-pre\-up
+A program or script which is executed just before the ppp network
+interface is brought up.  It is executed with the same parameters as
+the ipv6\-up script (below).  At this point the interface exists but is
+still down.  This can be used to add firewall rules before any IPv6 traffic
+can pass through the interface.  Pppd will wait for this script to finish
+before bringing the interface up, so this script should run quickly.
 .TP
 .B /etc/ppp/ipv6\-up
 Like /etc/ppp/ip\-up, except that it is executed when the link is available 


### PR DESCRIPTION
This option allow a user to specify the path to a script that will be run before the interface is brought up, similarly to the existing ip-pre-up script.