### PR TITLE
pppd: Add noresolvconf option

### DIFF
--- a/pppd/ipcp.c
+++ b/pppd/ipcp.c
@@ -88,6 +88,7 @@ static int default_route_set[NUM_PPP];	/* Have set up a default route */
 static int proxy_arp_set[NUM_PPP];	/* Have created proxy arp entry */
 static bool usepeerdns;			/* Ask peer for DNS addrs */
 static bool usepeerwins;		/* Ask peer for WINS addrs */
+static bool noresolvconf;		/* Do not create resolv.conf */
 static int ipcp_is_up;			/* have called np_up() */
 static int ipcp_is_open;		/* haven't called np_finished() */
 static bool ask_for_local;		/* request our address from peer */
@@ -218,6 +219,9 @@ static struct option ipcp_option_list[] = {
 
     { "usepeerwins", o_bool, &usepeerwins,
       "Ask peer for WINS address(es)", 1 },
+
+    { "noresolvconf", o_bool, &noresolvconf,
+      "Do not create resolv.conf", 1 },
 
     { "netmask", o_special, (void *)setnetmask,
       "set netmask", OPT_PRIO | OPT_A2STRVAL | OPT_STATIC, netmask_str },
@@ -2151,6 +2155,9 @@ static void
 create_resolv(u_int32_t peerdns1, u_int32_t peerdns2)
 {
     FILE *f;
+
+    if (noresolvconf)
+	return;
 
     f = fopen(PPP_PATH_RESOLV, "w");
     if (f == NULL) {

--- a/pppd/pppd.8
+++ b/pppd/pppd.8
@@ -1200,7 +1200,8 @@ by the peer (if any) are passed to the /etc/ppp/ip\-up script in the
 environment variables DNS1 and DNS2, and the environment variable
 USEPEERDNS will be set to 1.  In addition, pppd will create an
 /etc/ppp/resolv.conf file containing one or two nameserver lines with
-the address(es) supplied by the peer.
+the address(es) supplied by the peer (unless the \fInoresolvconf\fR
+option is given).
 .TP
 .B usepeerwins
 Ask the peer for up to 2 WINS server addresses.  The addresses supplied
@@ -1211,6 +1212,9 @@ USEPEERWINS will be set to 1.
 Please note that some modems (like the Huawei E220) requires this option in
 order to avoid a race condition that results in the incorrect DNS servers
 being assigned.
+.TP
+.B noresolvconf
+Do not create the /etc/ppp/resolv.conf file.
 .TP
 .B user \fIname
 Sets the name used for authenticating the local system to the peer to


### PR DESCRIPTION
This option allows a user to specify that he does not want to create the /etc/ppp/resolv.conf file with the DNS server addresses.