### PR TITLE
pppd: Add net-init-script, net-pre-up-script and net-down-script options

### DIFF
--- a/pppd/main.c
+++ b/pppd/main.c
@@ -363,6 +363,10 @@ main(int argc, char *argv[])
     struct protent *protp;
     char numbuf[16];
 
+    strlcpy(path_net_init, PPP_PATH_NET_INIT, MAXPATHLEN);
+    strlcpy(path_net_preup, PPP_PATH_NET_PREUP, MAXPATHLEN);
+    strlcpy(path_net_down, PPP_PATH_NET_DOWN, MAXPATHLEN);
+
     strlcpy(path_ipup, PPP_PATH_IPUP, MAXPATHLEN);
     strlcpy(path_ipdown, PPP_PATH_IPDOWN, MAXPATHLEN);
 
@@ -844,7 +848,7 @@ set_ifunit(int iskey)
 	create_pidfile(getpid());	/* write pid to file */
 	create_linkpidfile(getpid());
     }
-    run_net_script(PPP_PATH_NET_INIT, 1);
+    run_net_script(path_net_init, 1);
 }
 
 /*
@@ -1252,7 +1256,7 @@ new_phase(ppp_phase_t p)
 	if (phase <= PHASE_NETWORK) {
 	    char iftmpname[IFNAMSIZ];
 	    int ifindex = if_nametoindex(ifname);
-	    run_net_script(PPP_PATH_NET_PREUP, 1);
+	    run_net_script(path_net_preup, 1);
 	    if (if_indextoname(ifindex, iftmpname) && strcmp(iftmpname, ifname)) {
 		info("Detected interface name change from %s to %s.", ifname, iftmpname);
 		strcpy(ifname, iftmpname);
@@ -1260,7 +1264,7 @@ new_phase(ppp_phase_t p)
 	}
 	break;
     case PHASE_DISCONNECT:
-	run_net_script(PPP_PATH_NET_DOWN, 0);
+	run_net_script(path_net_down, 0);
 	break;
     }
 

--- a/pppd/options.c
+++ b/pppd/options.c
@@ -121,6 +121,9 @@ char	linkname[MAXPATHLEN];	/* logical name for link */
 bool	tune_kernel;		/* may alter kernel settings */
 int	connect_delay = 1000;	/* wait this many ms after connect script */
 int	req_unit = -1;		/* requested interface unit */
+char	path_net_init[MAXPATHLEN]; /* pathname of net-init script */
+char	path_net_preup[MAXPATHLEN];/* pathname of net-pre-up script */
+char	path_net_down[MAXPATHLEN]; /* pathname of net-down script */
 char	path_ipup[MAXPATHLEN];	/* pathname of ip-up script */
 char	path_ipdown[MAXPATHLEN];/* pathname of ip-down script */
 char	req_ifname[IFNAMSIZ];	/* requested interface name */
@@ -330,6 +333,16 @@ struct option general_options[] = {
     { "defaultroute-metric", o_int, &dfl_route_metric,
       "Metric to use for the default route (Linux only; -1 for default behavior)",
       OPT_PRIV|OPT_LLIMIT|OPT_INITONLY, NULL, 0, -1 },
+
+    { "net-init-script", o_string, path_net_init,
+      "Set pathname of net-init script",
+      OPT_PRIV|OPT_STATIC, NULL, MAXPATHLEN },
+    { "net-pre-up-script", o_string, path_net_preup,
+      "Set pathname of net-preup script",
+      OPT_PRIV|OPT_STATIC, NULL, MAXPATHLEN },
+    { "net-down-script", o_string, path_net_down,
+      "Set pathname of net-down script",
+      OPT_PRIV|OPT_STATIC, NULL, MAXPATHLEN },
 
     { "ip-up-script", o_string, path_ipup,
       "Set pathname of ip-up script",

--- a/pppd/pppd-private.h
+++ b/pppd/pppd-private.h
@@ -192,6 +192,9 @@ extern bool	tune_kernel;	/* May alter kernel settings as necessary */
 extern int	connect_delay;	/* Time to delay after connect script */
 extern int	max_data_rate;	/* max bytes/sec through charshunt */
 extern int	req_unit;	/* interface unit number to use */
+extern char	path_net_init[]; /* pathname of net-init script */
+extern char	path_net_preup[];/* pathname of net-pre-up script */
+extern char	path_net_down[]; /* pathname of net-down script */
 extern char	path_ipup[]; 	/* pathname of ip-up script */
 extern char	path_ipdown[];	/* pathname of ip-down script */
 extern char	req_ifname[]; /* interface name to use (IFNAMSIZ) */


### PR DESCRIPTION
These options allow a user to specify paths to scripts usually located at /etc/ppp/net-init, /etc/ppp/net-pre-up and /etc/ppp/net-down, similarly to the existing ip-up-script and ip-down-script options.