### PR TITLE
ci: Updated the Solaris action to benefit from the faster VM.

### DIFF
--- a/.github/workflows/solaris.yaml
+++ b/.github/workflows/solaris.yaml
@@ -8,7 +8,7 @@ jobs:
     - name: Checkout PPP sources
       uses: actions/checkout@v4
     - name: Build
-      uses: vmactions/solaris-vm@v1.0.2
+      uses: vmactions/solaris-vm@v1.0.9
       with:
         release: "11.4-gcc"
         run: |


### PR DESCRIPTION
The total execution decreased by about 20%, sometimes even more.
The best execution time since now has been 2 minutes 52 seconds when the average time with the old VM is about 6 minutes.