### PR TITLE
disable holdoff for reconnect on timeout or link failure

### DIFF
--- a/pppd/auth.c
+++ b/pppd/auth.c
@@ -1331,6 +1331,7 @@ connect_time_expired(void *arg)
     info("Connect time expired");
     ppp_set_status(EXIT_CONNECT_TIME);
     lcp_close(0, "Connect time expired");	/* Close connection */
+    need_holdoff = 0;
 }
 
 /*

--- a/pppd/main.c
+++ b/pppd/main.c
@@ -611,8 +611,10 @@ main(int argc, char *argv[])
 	while (phase != PHASE_DEAD) {
 	    handle_events();
 	    get_input();
-	    if (kill_link)
+	    if (kill_link) {
 		lcp_close(0, "User request");
+		need_holdoff = 0;
+	    }
 	    if (asked_to_quit) {
 		bundle_terminating = 1;
 		if (phase == PHASE_MASTER)
@@ -1153,6 +1155,7 @@ get_input(void)
 	notice("Modem hangup");
 	hungup = 1;
 	code = EXIT_HANGUP;
+	need_holdoff = 0;
 	lcp_lowerdown(0);	/* serial link is no longer available */
 	link_terminated(0);
 	return;

--- a/pppd/pppd.8
+++ b/pppd/pppd.8
@@ -475,7 +475,8 @@ exclude the password string from the log.  This is the default.
 Specifies how many seconds to wait before re-initiating the link after
 it terminates.  This option only has any effect if the \fIpersist\fR
 or \fIdemand\fR option is used.  The holdoff period is not applied if
-the link was terminated because it was idle.
+the link was terminated because it was idle, connect time expired,
+modem hangup or user request.
 .TP
 .B idle \fIn
 Specifies that pppd should disconnect if the link is idle for \fIn\fR


### PR DESCRIPTION
This PR will cover cases where connection must be reestablished as fast as possible to descrease network downtime:
- connect time expired (ex: connection time limit for billing purposes or dynamic IP change)
- user request (ex: ISP peer shutting down and we must reconnect to another available in pool)
- connection lost (ex: we got cable disconnection or packet loss for a few seconds)