### PR TITLE
.gitattributes to exclude .git* files from git-archive.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Exclude .git* files from being exported.
+.git* export-ignore


### PR DESCRIPTION
This relates to #519 and addresses the portion where "we can also exclude things like /.github/ from the release".