### PR TITLE
Rework default route handling.

### DIFF
--- a/pppd/ipcp.h
+++ b/pppd/ipcp.h
@@ -76,7 +76,6 @@ typedef struct ipcp_options {
     bool old_addrs;		/* Use old (IP-Addresses) option? */
     bool req_addr;		/* Ask peer to send IP address? */
     bool default_route;		/* Assign default route through interface? */
-    bool replace_default_route;	/* Replace default route through interface? */
     bool proxy_arp;		/* Make proxy ARP entry for peer? */
     bool neg_vj;		/* Van Jacobson Compression? */
     bool old_vj;		/* use old (short) form of VJ option? */

--- a/pppd/ipv6cp.c
+++ b/pppd/ipv6cp.c
@@ -179,6 +179,8 @@ ipv6cp_options ipv6cp_allowoptions[NUM_PPP];	/* Options we allow peer to request
 ipv6cp_options ipv6cp_hisoptions[NUM_PPP];	/* Options that we ack'd */
 int no_ifaceid_neg = 0;
 
+unsigned dfl_route6_metric = 0;	/* metric of the default route to set over the PPP link */
+
 /* local vars */
 static int default_route_set[NUM_PPP];		/* Have set up a default route */
 static int ipv6cp_is_up;
@@ -257,6 +259,10 @@ static struct option ipv6cp_option_list[] = {
     { "-defaultroute6", o_bool, &ipv6cp_allowoptions[0].default_route,
       "disable defaultroute6 option", OPT_ALIAS | OPT_A2CLR,
       &ipv6cp_wantoptions[0].default_route },
+
+    { "defaultroute6-metric", o_int, &dfl_route6_metric,
+      "Metric to use for the default route (Linux only; default 0)",
+      OPT_PRIV|OPT_LLIMIT|OPT_INITONLY, NULL, 0, -1 },
 
     { "ipv6cp-use-ipaddr", o_bool, &ipv6cp_allowoptions[0].use_ip,
       "Use (default) IPv4 addresses for both local and remote interface identifiers", 1 },

--- a/pppd/options.c
+++ b/pppd/options.c
@@ -136,7 +136,6 @@ bool	dryrun;			/* print out option values and exit */
 char	*domain;		/* domain name set by domain option */
 int	child_wait = 5;		/* # seconds to wait for children at exit */
 struct userenv *userenv_list;	/* user environment variables */
-int	dfl_route_metric = -1;	/* metric of the default route to set over the PPP link */
 
 #ifdef PPP_WITH_IPV6CP
 char	path_ipv6up[MAXPATHLEN];   /* pathname of ipv6-up script */
@@ -330,10 +329,6 @@ struct option general_options[] = {
     { "unset", o_special, (void *)user_unsetenv,
       "Unset user environment variable",
       OPT_A2PRINTER | OPT_NOPRINT, (void *)user_unsetprint },
-
-    { "defaultroute-metric", o_int, &dfl_route_metric,
-      "Metric to use for the default route (Linux only; -1 for default behavior)",
-      OPT_PRIV|OPT_LLIMIT|OPT_INITONLY, NULL, 0, -1 },
 
     { "net-init-script", o_string, path_net_init,
       "Set pathname of net-init script",

--- a/pppd/pppd-private.h
+++ b/pppd/pppd-private.h
@@ -430,7 +430,7 @@ int  sif6addr(int, eui64_t, eui64_t);
 int  cif6addr(int, eui64_t, eui64_t);
 				/* Remove an IPv6 address from i/f */
 #endif
-int  sifdefaultroute(int, u_int32_t, u_int32_t, bool replace_default_rt);
+int  sifdefaultroute(int, u_int32_t, u_int32_t);
 				/* Create default route through i/f */
 int  cifdefaultroute(int, u_int32_t, u_int32_t);
 				/* Delete default route through i/f */

--- a/pppd/pppd.8
+++ b/pppd/pppd.8
@@ -121,15 +121,8 @@ This entry is removed when the PPP connection is broken.  This option
 is privileged if the \fInodefaultroute\fR option has been specified.
 .TP
 .B defaultroute-metric
-Define the metric of the \fIdefaultroute\fR and only add it if there
-is no other default route with the same metric.  With the default
-value of -1, the route is only added if there is no default route at
-all.
-.TP
-.B replacedefaultroute
-This option is a flag to the defaultroute option. If defaultroute is
-set and this flag is also set, pppd replaces an existing default route
-with the new default route.  This option is privileged.
+Define the metric of the \fIdefaultroute\fR.  By default the default route will
+be added with a metric of 0.  This option is privileged.
 .TP
 .B disconnect \fIscript
 Execute the command specified by \fIscript\fR, by passing it to a
@@ -366,6 +359,10 @@ are managed by kernel (as apposite to IPv4) and IPv6 default route is
 configured by kernel automatically too based on ICMPv6 Router Advertisement
 packets.  This option may conflict with kernel IPv6 route setup and should
 be used only for broken IPv6 networks.
+.TP
+.B defaultroute6-metric
+Define the metric of the \fIdefaultroute6\fR.  By default the default route will
+be added with a metric of 0.  This option is privileged.
 .TP
 .B deflate \fInr,nt
 Request that the peer compress packets that it sends, using the
@@ -801,10 +798,6 @@ disable both forms of hardware flow control.
 Disable the \fIdefaultroute\fR option.  The system administrator who
 wishes to prevent users from adding a default route with pppd
 can do so by placing this option in the /etc/ppp/options file.
-.TP
-.B noreplacedefaultroute
-Disable the \fIreplacedefaultroute\fR option. This allows to disable a
-\fIreplacedefaultroute\fR option set previously in the configuration.
 .TP
 .B nodefaultroute6
 Disable the \fIdefaultroute6\fR option.  The system administrator who

--- a/pppd/sys-solaris.c
+++ b/pppd/sys-solaris.c
@@ -1724,14 +1724,9 @@ cifaddr(int u, u_int32_t o, u_int32_t h)
  * sifdefaultroute - assign a default route through the address given.
  */
 int
-sifdefaultroute(int u, u_int32_t l, u_int32_t g, bool replace)
+sifdefaultroute(int u, u_int32_t l, u_int32_t g)
 {
     struct rtentry rt;
-
-    if (replace) {
-	error("Replacing the default route is not implemented on Solaris yet");
-	return 0;
-    }
 
 #if defined(__USLC__)
     g = l;			/* use the local address as gateway */


### PR DESCRIPTION
1.  replacedefaultroute option is being removed.
2.  default route will now always be appended at defaultroute-metric (both IPv4 and IPv6) if defaultroute{.6} is given.

Closes: #473