### PR TITLE
pppd.8: fix groff warning

### DIFF
--- a/pppd/pppd.8
+++ b/pppd/pppd.8
@@ -691,7 +691,7 @@ network control protocol comes up).
 Terminate after \fIn\fR consecutive failed connection attempts.  A
 value of 0 means no limit.  The default value is 10.
 .TP
-.B max\-tls-\version \fIstring
+.B max\-tls\-version \fIstring
 (EAP-TLS, or PEAP) Configures the max allowed TLS version used during
 negotiation with a peer.  The default value for this is \fI1.2\fR.  Values
 allowed for this option is \fI1.0.\fR, \fI1.1\fR, \fI1.2\fR, \fI1.3\fR.


### PR DESCRIPTION
Warning picked up by Debian's lintian:
```
W: ppp: groff-message troff:<standard input>:694: warning: expected numeric expression, got 'r' [usr/share/man/man8/pppd.8.gz:1]
```