### PR TITLE
Fixed building with GCC 15

### DIFF
--- a/pppdump/pppdump.c
+++ b/pppdump/pppdump.c
@@ -42,14 +42,12 @@ int tot_sent, tot_rcvd;
 extern int optind;
 extern char *optarg;
 
-void dumplog();
-void dumpppp();
-void show_time();
+void dumplog(FILE *);
+void dumpppp(FILE *);
+void show_time(FILE *, int);
 
 int
-main(ac, av)
-    int ac;
-    char **av;
+main(int ac, char **av)
 {
     int i;
     char *p;
@@ -97,8 +95,7 @@ main(ac, av)
 }
 
 void
-dumplog(f)
-    FILE *f;
+dumplog(FILE *f)
 {
     int c, n, k, col;
     int nb, c2;
@@ -241,8 +238,7 @@ struct pkt {
 unsigned char dbuf[8192];
 
 void
-dumpppp(f)
-    FILE *f;
+dumpppp(FILE *f)
 {
     int c, n, k;
     int nb, nl, dn, proto, rv;
@@ -375,9 +371,7 @@ dumpppp(f)
 }
 
 void
-show_time(f, c)
-    FILE *f;
-    int c;
+show_time(FILE *f, int c)
 {
     time_t t;
     int n;


### PR DESCRIPTION
GCC 15 defaults to C23 which does not allow K&R declarations.

Credit Yaakov Selkowitz in:
https://src.fedoraproject.org/rpms/ppp/pull-request/12