### PR TITLE
Move inclusion of <linux/ppp_ioctl.h> to allow geriatric systems to build ppp.

### DIFF
--- a/pppd/plugins/pppol2tp/pppol2tp.c
+++ b/pppd/plugins/pppol2tp/pppol2tp.c
@@ -38,7 +38,6 @@
 
 #include <linux/version.h>
 #include <linux/sockios.h>
-#include <linux/ppp-ioctl.h>
 
 #ifndef aligned_u64
 /* should be defined in sys/types.h */
@@ -50,6 +49,8 @@
 #include <linux/ppp_defs.h>
 #include <linux/if_pppox.h>
 #include <linux/if_pppol2tp.h>
+
+#include <linux/ppp-ioctl.h>
 
 #include <pppd/pppd.h>
 #include <pppd/options.h>

--- a/pppd/sys-linux.c
+++ b/pppd/sys-linux.c
@@ -122,8 +122,6 @@
 #include <netinet/in.h>
 #include <arpa/inet.h>
 
-#include <linux/ppp-ioctl.h>
-
 #include <linux/netlink.h>
 #include <linux/rtnetlink.h>
 #include <linux/if_link.h>
@@ -155,6 +153,8 @@
 #endif /* PPP_WITH_IPV6CP */
 
 #include "multilink.h"
+
+#include <linux/ppp-ioctl.h>
 
 #ifdef PPP_WITH_FILTER
 #include <pcap-bpf.h>


### PR DESCRIPTION
Given a system with the following:
  - linux 4.4.302
  - kernel headers 3.4.104
  - gcc 4.7.3
  - binutils 2.22
  - glibc 2.18

Compiling ppp fails with the following errors:

```
x86_64-linux-gnu-gcc -std=gnu11 -DHAVE_CONFIG_H -I. -I../pppd/plugins/pppoe  -DSYSCONFDIR=\"/usr/etc\" -DPPPD_RUNTIME_DIR='"/usr/var/run/pppd"' -DPPPD_LOGFILE_DIR='"/usr/var/log/ppp"' -DSYSTEM_CA_PATH='"/usr/etc/ssl/certs"'   -DPPPD_PLUGIN_DIR='"/usr/lib/pppd/2.5.2"'       -O2 -m64 -fPIC -MT pppd-sys-linux.o -MD -MP -MF .deps/pppd-sys-linux.Tpo -c -o pppd-sys-linux.o `test -f 'sys-linux.c' || echo './'`sys-linux.c
In file included from sys-linux.c:125:0:
/usr/include/linux/ppp-ioctl.h:55:14: error: field 'mode' has incomplete type
make[3]: *** [Makefile:1334: pppd-sys-linux.o] Error 1
make[3]: Leaving directory '/build/sources/ppp/ppp-2.5.2/pppd'
make[2]: *** [Makefile:819: all] Error 2
make[2]: Leaving directory '/build/sources/ppp/ppp-2.5.2/pppd'
make[1]: *** [Makefile:505: all-recursive] Error 1
make[1]: Leaving directory '/build/sources/ppp/ppp-2.5.2'
make: *** [Makefile:31: compile] Error 2
make: Leaving directory '/build/sources/ppp'
```

and

```
libtool: compile:  x86_64-linux-gnu-gcc -std=gnu11 -DHAVE_CONFIG_H -I. -I../../../pppd -I../../../pppd/plugins/pppoe -I../../.. -O2 -m64 -fPIC -MT pppol2tp_la-pppol2tp.lo -MD -MP -MF .deps/pppol2tp_la-pppol2tp.Tpo -c pppol2tp.c  -fPIC -DPIC -o .libs/pppol2tp_la-pppol2tp.o In file included from pppol2tp.c:41:0:
/usr/include/linux/ppp-ioctl.h:55:14: error: field 'mode' has incomplete type make[3]: *** [Makefile:498: pppol2tp_la-pppol2tp.lo] Error 1 make[3]: Leaving directory '/build/sources/ppp/ppp-2.5.2/pppd/plugins/pppol2tp' make[2]: *** [Makefile:579: all-recursive] Error 1 make[2]: Leaving directory '/build/sources/ppp/ppp-2.5.2/pppd/plugins' make[1]: *** [Makefile:505: all-recursive] Error 1 make[1]: Leaving directory '/build/sources/ppp/ppp-2.5.2' make: *** [Makefile:31: compile] Error 2
make: Leaving directory '/build/sources/ppp'
```

They are likely due to the ordering of include files which changed in newer systems. The following two patches correct the error on my geriatric system.

```
--- ppp-2.5.2/pppd/sys-linux.c  2024-12-19 02:18:51.000000000 -0500
+++ ppp-2.5.2-new/pppd/sys-linux.c      2025-03-04 12:27:24.975267745 -0500
@@ -122,8 +122,6 @@
 #include <netinet/in.h>
 #include <arpa/inet.h>

-#include <linux/ppp-ioctl.h>
-
 #include <linux/netlink.h>
 #include <linux/rtnetlink.h>
 #include <linux/if_link.h>
@@ -156,6 +154,8 @@

 #include "multilink.h"

+#include <linux/ppp-ioctl.h>
+
 #ifdef PPP_WITH_FILTER
 #include <pcap-bpf.h>
 #include <linux/filter.h>
```

and

```
--- ppp-2.5.2/pppd/plugins/pppol2tp/pppol2tp.c  2023-11-09 01:17:25.000000000 -0500
+++ ppp-2.5.2-new/pppd/plugins/pppol2tp/pppol2tp.c      2025-03-04 12:28:43.001934416 -0500
@@ -38,7 +38,6 @@

 #include <linux/version.h>
 #include <linux/sockios.h>
-#include <linux/ppp-ioctl.h>

 #ifndef aligned_u64
 /* should be defined in sys/types.h */
@@ -51,6 +50,8 @@
 #include <linux/if_pppox.h>
 #include <linux/if_pppol2tp.h>

+#include <linux/ppp-ioctl.h>
+
 #include <pppd/pppd.h>
 #include <pppd/options.h>
 #include <pppd/fsm.h>
```

Unknowns:
  - Do these patches affect compiling on new(er) systems?
  - Are the changes are reasonably optimal?
  - Do the changes introduce operational faults?