### PR TITLE
pppd/session: Fixed building with GCC 15

### DIFF
--- a/pppd/session.c
+++ b/pppd/session.c
@@ -182,7 +182,6 @@ session_start(const int flags, const char *user, const char *passwd, const char 
     char *cbuf;
 #ifdef HAVE_SHADOW_H
     struct spwd *spwd;
-    struct spwd *getspnam();
     long now = 0;
 #endif /* #ifdef HAVE_SHADOW_H */
 #endif /* #ifdef PPP_WITH_PAM */


### PR DESCRIPTION
Fixed building with GCC 15 which defaults to C23
and find conflicting declration of getspnam() here with the one provided by shadow.h (extern struct spwd *getspnam (const char *__name);)

Fixes
../../ppp-2.5.2/pppd/session.c: In function 'session_start': ../../ppp-2.5.2/pppd/session.c:185:18: error: conflicting types for 'getspnam'; have 'struct spwd *(void)'
  185 |     struct spwd *getspnam();
      |                  ^~~~~~~~