### PR TITLE
pppd: Fix potential buffer overflow in lcp_rtt_update_buffer()

### DIFF
--- a/pppd/lcp.c
+++ b/pppd/lcp.c
@@ -2278,10 +2278,11 @@ lcp_rtt_update_buffer (unsigned long rtt)
     unsigned int next_entry, lost;
 
     /* choose the next entry where the data will be stored */
-    if (ntohl(ring_header[2]) >= (LCP_RTT_ELEMENTS - 1) * 2)
+    next_entry = ntohl(ring_header[2]);
+    if (next_entry >= (LCP_RTT_ELEMENTS - 1) * 2)
 	next_entry = 0;				/* go back to the beginning */
     else
-	next_entry = ntohl(ring_header[2]) + 2;	/* use the next one */
+	next_entry += 2;			/* use the next one */
 
     /* update the data element */
     /* storing the timestamp in an *unsigned* long allows dates up to 2106 */


### PR DESCRIPTION
It's possible for `ring_header[2]` to be modified by another process when reading it twice through a volatile pointer, causing it to change from a small value (which doesn't need to wrap around) to a large value which would exceed the size of the buffer.