### PR TITLE
Revert "pppd/options.c: fix memory leak on error path (#441)"

### DIFF
--- a/pppd/options.c
+++ b/pppd/options.c
@@ -613,9 +613,13 @@ ppp_options_from_file(char *filename, int must_exist, int check_prot, int priv)
 
 err:
     fclose(f);
-    free(option_source);
     privileged_option = oldpriv;
     option_source = oldsource;
+
+    /* Note that we usually leak option_source here.  This is OK
+     * since this code is only run during startup.  Other places
+     * makes copies of the pointer (shallow copy), and as such we
+     * have no choice but to leak that here */
     return ret;
 }
 


### PR DESCRIPTION
This reverts commit 26d1b60f4984fe71005c4f1a99691e714920f33c.

Additionally a comment is added so anyone looking at Coverity output will not be tempted to "fix" it again.

Closes: #560