### PR TITLE
pppd: add VRF binding support

### DIFF
--- a/pppd/main.c
+++ b/pppd/main.c
@@ -846,6 +846,10 @@ set_ifunit(int iskey)
 	slprintf(ifname, sizeof(ifname), "%s%d", PPP_DRV_NAME, ifunit);
     info("Using interface %s", ifname);
     ppp_script_setenv("IFNAME", ifname, iskey);
+#ifdef __linux__
+    if (req_vrf[0] != '\0')
+        ppp_script_setenv("VRF", req_vrf, iskey);
+#endif
     slprintf(ifkey, sizeof(ifkey), "%d", ifunit);
     ppp_script_setenv("UNIT", ifkey, iskey);
     if (iskey) {

--- a/pppd/options.c
+++ b/pppd/options.c
@@ -128,6 +128,9 @@ char	path_ipup[MAXPATHLEN];	/* pathname of ip-up script */
 char	path_ipdown[MAXPATHLEN];/* pathname of ip-down script */
 char	path_ippreup[MAXPATHLEN]; /* pathname of ip-pre-up script */
 char	req_ifname[IFNAMSIZ];	/* requested interface name */
+#ifdef __linux__
+char	req_vrf[IFNAMSIZ];	/* VRF name to bind with PPP interface */
+#endif
 bool	multilink = 0;		/* Enable multilink operation */
 char	*bundle_name = NULL;	/* bundle name for multilink */
 bool	dump_options;		/* print out option values */
@@ -313,6 +316,12 @@ struct option general_options[] = {
     { "ifname", o_string, req_ifname,
       "Set PPP interface name",
       OPT_PRIO | OPT_PRIV | OPT_STATIC, NULL, IFNAMSIZ },
+
+#ifdef __linux__
+    { "vrf", o_string, req_vrf,
+      "Bind PPP interface to the specified VRF and install routes in its routing table",
+      OPT_PRIO | OPT_PRIV | OPT_STATIC, NULL, IFNAMSIZ },
+#endif
 
     { "dump", o_bool, &dump_options,
       "Print out option values after parsing all options", 1 },

--- a/pppd/pppd-private.h
+++ b/pppd/pppd-private.h
@@ -203,6 +203,9 @@ extern char	path_ipup[]; 	/* pathname of ip-up script */
 extern char	path_ipdown[];	/* pathname of ip-down script */
 extern char	path_ippreup[];	/* pathname of ip-pre-up script */
 extern char	req_ifname[]; /* interface name to use (IFNAMSIZ) */
+#ifdef __linux__
+extern char	req_vrf[];	/* VRF name to bind with PPP interface */
+#endif
 extern bool	multilink;	/* enable multilink operation (options.c) */
 extern bool	noendpoint;	/* don't send or accept endpt. discrim. */
 extern char	*bundle_name;	/* bundle name for multilink */

--- a/pppd/pppd.8
+++ b/pppd/pppd.8
@@ -1165,6 +1165,12 @@ Set the ppp interface name for outbound connections.  If the interface name is
 already in use, or if the name cannot be used for any other reason, pppd will
 terminate.
 .TP
+.B vrf \fIname
+Bind the ppp interface to the existing VRF (Virtual Routing and Forwarding)
+instance \fIname\fR on Linux.  Routes installed by pppd will go into the
+routing table of VRF \fIname\fR instead of the default table.  This option
+is only available on Linux systems that support VRF.
+.TP
 .B unset \fIname
 Remove a variable from the environment variable for scripts that are
 invoked by pppd.  When specified by a privileged source, the variable
@@ -1758,6 +1764,10 @@ The name of the serial tty device being used.
 .TP
 .B IFNAME
 The name of the network interface being used.
+.TP
+.B VRF
+The name of the VRF to which the ppp interface is bound.  This is only set if
+the ppp interface has been bound to a VRF using the \fIvrf\fR option.
 .TP
 .B IPLOCAL
 The IP address for the local end of the link.  This is only set when


### PR DESCRIPTION
Hello,

This PR introduces vrf support to pppd and will resolve https://github.com/ppp-project/ppp/issues/311

Tested on Ubuntu 24.04, using accel-pppd for the ppp server:

Setup:
```sh
sudo ip link add sessions type vrf table 1234
sudo ip link set sessions up
```

Client config:
```
plugin pppoe.so
nic-veth1
ifname PPPOE
vrf sessions
user "testuser"
noauth
defaultroute
usepeerdns
```

Start PPPoE session:
```sh
sudo pppd call test debug dump nodetach
```

Check that the ppp interface belongs to the vrf 'sessions':
```sh
ip link show PPPOE 
```
```
128: PPPOE: <POINTOPOINT,MULTICAST,NOARP,UP,LOWER_UP> mtu 1492 qdisc fq_codel master sessions state UNKNOWN mode DEFAULT group default qlen 3
    link/ppp
```
^^^ The ppp interface belongs to the vrf sessions (master sessions)


Check that the routes installed by pppd are located in the routing table of the vrf 'sessions':
```sh
ip route show table 1234
```
```
default dev PPPOE scope link                         ### default route installed by pppd
10.0.0.1 dev PPPOE proto kernel scope link src 10.0.0.10         ### route installed by the kernel
local 10.0.0.10 dev PPPOE proto kernel scope host src 10.0.0.10       ### route installed by the kernel
```


The same test has been performed successfully without setting the ifname to
be able to test both when the ppp interface is created thought netlink or via ioctl on the ppp driver.

```
plugin pppoe.so
nic-veth1
### ifname PPPOE
vrf sessions
user "testuser"
noauth
defaultroute
usepeerdns
```
