### PR TITLE
dhcpv6relay plugin: Make all sockets non-blocking.

### DIFF
--- a/pppd/plugins/dhcpv6relay/dhcpv6relay.c
+++ b/pppd/plugins/dhcpv6relay/dhcpv6relay.c
@@ -416,7 +416,7 @@ void dhcpv6relay_server_event(int fd, void*)
     socklen_t slen = sizeof(sa);
     bool valid_source = true;
     int hlim = 0;
-    ssize_t r = recvfrom(fd, buffer, sizeof(buffer), MSG_DONTWAIT,
+    ssize_t r = recvfrom(fd, buffer, sizeof(buffer), MSG_DONTWAIT | MSG_TRUNC,
 	    (struct sockaddr*)&sa, &slen);
     if (r < 0) {
 	error("DHCPv6 relay: Failed to read from %s socket: %s",
@@ -424,8 +424,8 @@ void dhcpv6relay_server_event(int fd, void*)
 		strerror(errno));
 	return;
     }
-    if (r >= sizeof(buffer)) {
-	error("DHCPv6 buffer overrun, recvfrom returned %d, max %u",
+    if (r > sizeof(buffer)) {
+	error("DHCPv6 relay: buffer overrun receiving packet of length %db received with a buffer of size %ub from the DHCP server",
 		r, sizeof(buffer));
 	return;
     }
@@ -590,7 +590,7 @@ void dhcpv6relay_client_event(int fd, void*)
     struct sockaddr_in6 sa;
     uint16_t sport;
     socklen_t slen = sizeof(sa);
-    ssize_t r = recvfrom(fd, buffer, sizeof(buffer), MSG_DONTWAIT,
+    ssize_t r = recvfrom(fd, buffer, sizeof(buffer), MSG_DONTWAIT | MSG_TRUNC,
 	    (struct sockaddr*)&sa, &slen);
     if (r < 0) {
 	if (errno != EAGAIN)
@@ -599,8 +599,8 @@ void dhcpv6relay_client_event(int fd, void*)
 		    strerror(errno));
 	return;
     }
-    if (r >= sizeof(buffer)) {
-	error("DHCPv6 relay: buffer overrun, recvfrom returned %d, max %u (%s socket)",
+    if (r > sizeof(buffer)) {
+	error("DHCPv6 relay: buffer overrun receiving packet of length %db received with a buffer of size %ub from the DHCP client",
 		r, sizeof(buffer), fd == dhcpv6relay_sock_ll ? "LL" : "MC");
 	return;
     }


### PR DESCRIPTION
$ strace -p 3701
strace: Process 3701 attached
read(14^C^Cstrace: Process 3701 detached

$ ls -lah /proc/3701/fd/14
lrwx------ 1 root root 64 Oct 22 02:52 /proc/3701/fd/14 -> 'socket:[2478479691]'

$ grep 2478479691 /proc/net/{udp,tcp,raw}*
/proc/net/raw6:  118: 000002FF000000000000000002000100:003A 00000000000000000000000000000000:0000 07 00000000:00000000 00:00000000 00000000     0        0 2478479691 2 00000000c0af204a 0

So it's blocking trying to receive RS.  This seems bogus, as the only raw socket is dhcpv6relay_sock_rsra, and this only ever gets read from dhcpv6relay_router_solicitation which should only ever be called if event-handler determines there's data available.

All sockets are datagram (and by implication already deemed "unreliable") based, so making them all non-blocking should have no adverse effect, however, blocking pppd process most certainly has undesired effects.