### PR TITLE
pppd: Make set and unset options privileged [security]

### DIFF
--- a/pppd/options.c
+++ b/pppd/options.c
@@ -334,10 +334,10 @@ struct option general_options[] = {
 
     { "set", o_special, (void *)user_setenv,
       "Set user environment variable",
-      OPT_A2PRINTER | OPT_NOPRINT, (void *)user_setprint },
+      OPT_A2PRINTER | OPT_NOPRINT | OPT_PRIV, (void *)user_setprint },
     { "unset", o_special, (void *)user_unsetenv,
       "Unset user environment variable",
-      OPT_A2PRINTER | OPT_NOPRINT, (void *)user_unsetprint },
+      OPT_A2PRINTER | OPT_NOPRINT | OPT_PRIV, (void *)user_unsetprint },
 
     { "net-init-script", o_string, path_net_init,
       "Set pathname of net-init script",


### PR DESCRIPTION
Since the "set" and "unset" options affect the environment passed to scripts that run as root, and environment variable settings could affect or disrupt the execution of those scripts, these options should be privileged.