### PR TITLE
pppd: Remove dead check for existence of route to remote IP

### DIFF
--- a/pppd/auth.c
+++ b/pppd/auth.c
@@ -2143,7 +2143,7 @@ auth_ip_addr(int unit, u_int32_t addr)
 
     if (auth_required)
 	return 0;		/* no addresses authorized */
-    return allow_any_ip || privileged || !have_route_to(addr);
+    return allow_any_ip || privileged;
 }
 
 static int


### PR DESCRIPTION
The have_route_to() call in auth_ip_addr() is dead code, so remove it. It can never be reached because, to reach it, we would have to have !auth_required && !allow_any_ip && !privileged, but auth_check_options() sets auth_required to 1 in that case.

In other words, the logic established by previous commits is this:

If pppd is run by non-root and the noauth option isn't in effect, or if the auth option is given, the peer has to authenticate, and the IP addresses are controlled by the secrets file, with no reachability check.

If pppd is run by root and authentication isn't required (i.e. the auth option is not given), the peer can use any IP address, with no reachability check.

In neither case is the reachability check done by have_route_to() used.