### PR TITLE
pppd: Add checks to avoid out-of-bounds writes to static data

### DIFF
--- a/pppd/fsm.c
+++ b/pppd/fsm.c
@@ -762,12 +762,13 @@ void
 fsm_sdata(fsm *f, int code, int id, u_char *data, int datalen)
 {
     u_char *outp;
-    int outlen;
+    int outlen, mtu;
 
     /* Adjust length to be smaller than MTU */
     outp = outpacket_buf;
-    if (datalen > peer_mru[f->unit] - HEADERLEN)
-	datalen = peer_mru[f->unit] - HEADERLEN;
+    mtu = MIN(peer_mru[f->unit], PPP_MRU) - HEADERLEN;
+    if (datalen > mtu)
+	datalen = mtu;
     if (datalen && data != outp + PPP_HDRLEN + HEADERLEN)
 	BCOPY(data, outp + PPP_HDRLEN + HEADERLEN, datalen);
     outlen = datalen + HEADERLEN;

--- a/pppd/ipcp.c
+++ b/pppd/ipcp.c
@@ -1709,13 +1709,14 @@ endswitch:
     /*
      * If we aren't rejecting this packet, and we want to negotiate
      * their address, and they didn't send their address, then we
-     * send a NAK with a CI_ADDR option appended.  We assume the
+     * send a NAK with a CI_ADDR option appended.  We check that the
      * input buffer is long enough that we can append the extra
      * option safely.
      */
     if (rc != CONFREJ && !ho->neg_addr && !ho->old_addrs &&
 	wo->req_addr && !reject_if_disagree &&
-	((wo->hisaddr && !wo->accept_remote) || !noremoteip)) {
+	((wo->hisaddr && !wo->accept_remote) || !noremoteip) &&
+	(rc == CONFACK || ucp + CILEN_ADDR <= inp + PPP_MRU - HEADERLEN)) {
 	if (rc == CONFACK) {
 	    rc = CONFNAK;
 	    ucp = inp;			/* reset pointer */


### PR DESCRIPTION
Add checks to avoid out-of-bounds writes to inpacket_buf and outtpacket_buf, which are both statically allocated arrays.

In ipcp_reqci(), there is code that appends a CI_ADDR option to the list of options being returned as a Configure-Nak.  Add a check to this code to ensure that there is sufficient space to append the option, so that a malicious peer can't cause the code to write past the end of inpacket_buf (which is what 'inp' points to).

In fsm_sdata(), the code that trims the length of the outgoing packet to the peer's MRU could potentially result in the length being greater than 1500, causing the following code to write beyond the end of the outpacket_buf array if the peer has negotiated an MRU larger than
1500.  To prevent this, limit the length to 1500 or the peer's MRU, whichever is smaller.

These issues were found by Sebastian Eisenreich-Dietz (CyberDanube) in cooperation with A&R TECH.