### PR TITLE
pppd: fix printf format on long type

### DIFF
--- a/pppd/eap-tls.c
+++ b/pppd/eap-tls.c
@@ -161,7 +161,7 @@ CONF *eaptls_ssl_load_config( void )
     ret_code = NCONF_load( config, PPP_PATH_OPENSSLCONFFILE, &error_line );
     if (ret_code == 0)
     {
-        warn( "EAP-TLS: Error in OpenSSL config file %s at line %d", PPP_PATH_OPENSSLCONFFILE, error_line );
+        warn( "EAP-TLS: Error in OpenSSL config file %s at line %ld", PPP_PATH_OPENSSLCONFFILE, error_line );
         NCONF_free( config );
         config = NULL;
         ERR_clear_error();

--- a/pppd/tls.c
+++ b/pppd/tls.c
@@ -321,7 +321,7 @@ int tls_set_version(SSL_CTX *ctx, const char *max_version)
         }
     }
 
-    dbglog("Setting max protocol version to 0x%X", tls_version);
+    dbglog("Setting max protocol version to 0x%lX", tls_version);
     if (!SSL_CTX_set_max_proto_version(ctx, tls_version)) {
         error("Could not set max protocol version");
         return -1;


### PR DESCRIPTION
Reported by GCC when `__attribute__((format(printf)))` is declared:
```
tls.c: In function 'tls_set_version':
tls.c:324:48: warning: format '%X' expects argument of type 'unsigned int', but argument 2 has type 'long int' [-Wformat=]
  324 |     dbglog("Setting max protocol version to 0x%X", tls_version);
      |                                               ~^   ~~~~~~~~~~~
      |                                                |   |
      |                                                |   long int
      |                                                unsigned int
      |                                               %lX
eap-tls.c: In function 'eaptls_ssl_load_config':
eap-tls.c:164:66: warning: format '%d' expects argument of type 'int', but argument 3 has type 'long int' [-Wformat=]
  164 |         warn( "EAP-TLS: Error in OpenSSL config file %s at line %d", PPP_PATH_OPENSSLCONFFILE, error_line );
      |                                                                 ~^                             ~~~~~~~~~~
      |                                                                  |                             |
      |                                                                  int                           long int
      |                                                                 %ld
```
Fix the printf format.