### PR TITLE
fix: free ets->data on error paths in eaptls_receive and eaptls_free_…

### DIFF
--- a/pppd/eap-tls.c
+++ b/pppd/eap-tls.c
@@ -802,6 +802,7 @@ void eaptls_free_session(struct eaptls_session *ets)
     if (ets->info)
         tls_free_verify_info(&ets->info);
 
+    free(ets->data);
     free(ets);
 }
 
@@ -888,11 +889,15 @@ int eaptls_receive(struct eaptls_session *ets, u_char * inp, int len)
 
     if (len < 0) {
         warn("EAP-TLS: received malformed data");
+        free(ets->data);
+        ets->data = NULL;
         return 1;
     }
 
     if (len + ets->datalen > ets->tlslen) {
         warn("EAP-TLS: received data > TLS message length");
+        free(ets->data);
+        ets->data = NULL;
         return 1;
     }
 
@@ -907,6 +912,8 @@ int eaptls_receive(struct eaptls_session *ets, u_char * inp, int len)
 
         if (ets->datalen != ets->tlslen) {
             warn("EAP-TLS: received data != TLS message length");
+            free(ets->data);
+            ets->data = NULL;
             return 1;
         }
 


### PR DESCRIPTION
## Summary

  `eaptls_receive()` allocates `ets->data` to reassemble fragmented EAP-TLS messages, but three early-return error paths fail to free it.`eaptls_free_session()` also leaks `ets->data` when cleaning up thesession.
  Each triggered error leaks up to 64KB. An attacker can repeatedly send malformed EAP-TLS packets (LI=1, MF=0, tlslen=65536, tiny payload) to exhaust memory and cause denial of service.

  ## Affected code
  `pppd/eap-tls.c` — `eaptls_receive()` and `eaptls_free_session()`