### PR TITLE
pppd: suppress unconditional "Plugin ... loaded" message before daemonization

### DIFF
--- a/pppd/options.c
+++ b/pppd/options.c
@@ -1839,7 +1839,7 @@ loadplugin(char **argv)
 		     arg, vers, VERSION);
 	goto errclose;
     }
-    info("Plugin %s loaded.", arg);
+    dbglog("Plugin %s loaded.", arg);
     (*init)();
     if (path != arg)
 	free(path);


### PR DESCRIPTION
### Problem

`pppd` currently emits:

```
Plugin <plugin>.so loaded.
```

via `info()` immediately after successfully loading a plugin.

This happens very early during startup, before the daemon has fully detached. As a result, the message is not only sent to syslog but may also appear on the caller's terminal/stdout/stderr path, depending on how `pppd` was started.

A practical example is the common `pon` workflow:

```
pon myprovider
```

Even when running in a non-debug, non-interactive setup, the user sees:

```
Plugin sstp-pppd-plugin.so loaded.
```

printed during startup.

### Why this is undesirable

Successful plugin loading is a normal internal initialization step, not an operational event that typically requires user attention.

The message is especially surprising because:

* it is emitted even when debug logging is disabled;
* it appears before daemonization is complete;
* it can leak into the output of higher-level orchestration tools (`pon`, network managers, init systems, ifupdown integrations, etc.);
* it creates noise for scripts that expect startup to be silent unless an error occurs.

In my case, an SSTP connection managed through `pon`/`ifupdown-ng` produces a visible line on startup even though the connection succeeds and debug logging is not enabled.

### Suggested change

Move the message from:

```c
info("Plugin %s loaded.", filename);
```

to:

```c
dbglog("Plugin %s loaded.", filename);
```

This preserves the information for troubleshooting while avoiding unsolicited output during normal operation.

### Rationale

Plugin load success is primarily useful for debugging startup issues. In normal production operation, administrators are generally interested in failures to load a plugin, not successful loads of expected plugins.

Making the message debug-only would align it with the principle that non-debug startup should remain quiet unless there is an actual warning or error.