### PR TITLE
Check walk instead of text

### DIFF
--- a/pppd/plugins/pppoatm/text2atm.c
+++ b/pppd/plugins/pppoatm/text2atm.c
@@ -85,7 +85,7 @@ static int do_try_nsap(const char *text,struct sockaddr_atmsvc *addr,int flags)
 	    if (count++ == 15) break;
 	    dot = 1;
 	}
-	else if (*text != '.') break;
+	else if (*walk != '.') break;
 	    else if (!dot) return FATAL; /* two dots in a row */
 		else dot = 0;
     if (*walk != ':') {


### PR DESCRIPTION
We are checking for the walk location of the dot, not the start of the string.