### PR TITLE
Fix unhandled unknown tls-verify-method and uninitialized buffers in TLS verification

### DIFF
--- a/pppd/tls.c
+++ b/pppd/tls.c
@@ -94,8 +94,8 @@ static inline int SSL_CTX_set_max_proto_version(SSL_CTX *ctx, long tls_ver_max)
  */
 static int tls_verify_callback(int ok, X509_STORE_CTX *ctx)
 {
-    char subject[256];
-    char cn_str[256];
+    char subject[256] = {0};
+    char cn_str[256] = {0};
     X509 *peer_cert;
     int err, depth;
     SSL *ssl;
@@ -192,6 +192,11 @@ static int tls_verify_callback(int ok, X509_STORE_CTX *ctx)
             if (off > 0) {
                 ptr2 = cn_str + off;
             }
+        }
+
+        if (ptr2 == NULL) {
+            error("Certificate verification error: unknown tls-verify-method: %s", tls_verify_method);
+            return 0;
         }
 
         if (strcmp(ptr1, ptr2)) {


### PR DESCRIPTION
If the user provides an unknown tls-verify-method option, the certificate verification logic would previously fall through and leave ptr2 uninitialized (NULL), leading to a segmentation fault when attempting to call 'strcmp'.