### PR TITLE
pppd/EAP: Don't send EAP Nak packets as an authentication server

### DIFF
--- a/pppd/eap.c
+++ b/pppd/eap.c
@@ -2501,7 +2501,8 @@ eap_response(eap_state *esp, u_char *inp, int id, int len)
 			/* If MSCHAPv2 digest was not found, NAK the packet */
 			if (!esp->es_server.digest) {
 				error("EAP MSCHAPv2 not supported");
-				eap_send_nak(esp, id, EAPT_SRP);
+				esp->es_server.ea_state = eapIdentify;
+				eap_figure_next_state(esp, 0);
 				break;
 			}
 			esp->es_server.ea_state = eapMSCHAPv2Chall;
@@ -2709,7 +2710,7 @@ eap_response(eap_state *esp, u_char *inp, int id, int len)
 			break;
 		default:
 			error("EAP: Unhandled MSCHAPv2 opcode %d", opcode);
-			eap_send_nak(esp, id, EAPT_SRP);
+			eap_send_failure(esp);
 		}
 
 		break;


### PR DESCRIPTION
In the EAP negotiation, when we're authenticating the peer, we should never send an EAP Request-Nak packet; in fact such a packet is not defined in the EAP RFC.  We were doing that in two cases; (a) when the peer sends an EAP Response-Nak to suggest that we ask it for MS-CHAPv2, but we don't have MS-CHAPv2 support compiled in, or (b) if we receive an EAP-MSCHAPv2 response that we don't recognize.  Instead of sending a Nak, in the first case we restart the authentication process from the beginning, and in the second case we fail the authentication.