### PR TITLE
Radius plugin hardening

### DIFF
--- a/pppd/plugins/radius/avpair.c
+++ b/pppd/plugins/radius/avpair.c
@@ -471,11 +471,13 @@ void rc_avpair_free (VALUE_PAIR *pair)
  * Purpose: Copy a data field from the buffer.  Advance the buffer
  *          past the data field.
  *
+ * 'string' is assumed to have space for AUTH_ID_LEN characters.
  */
 
 static void rc_fieldcpy (char *string, char **uptr)
 {
 	char           *ptr;
+	char *stringstart = string;
 
 	ptr = *uptr;
 	if (*ptr == '"')
@@ -483,6 +485,8 @@ static void rc_fieldcpy (char *string, char **uptr)
 		ptr++;
 		while (*ptr != '"' && *ptr != '\0' && *ptr != '\n')
 		{
+			if (string - stringstart >= AUTH_ID_LEN - 1)
+				goto bad;
 			*string++ = *ptr++;
 		}
 		*string = '\0';
@@ -497,11 +501,17 @@ static void rc_fieldcpy (char *string, char **uptr)
 	while (*ptr != ' ' && *ptr != '\t' && *ptr != '\0' && *ptr != '\n' &&
 			*ptr != '=' && *ptr != ',')
 	{
+		if (string - stringstart >= AUTH_ID_LEN - 1)
+			goto bad;
 		*string++ = *ptr++;
 	}
 	*string = '\0';
 	*uptr = ptr;
 	return;
+
+ bad:
+	fatal("radius: A-V pair name or value is too long (max %d chars)",
+	      AUTH_ID_LEN - 1);
 }
 
 
@@ -589,7 +599,7 @@ int rc_avpair_parse (char *buffer, VALUE_PAIR **first_pair)
 				}
 				return (-1);
 			}
-			strcpy (pair->name, attr->name);
+			strlcpy (pair->name, attr->name, sizeof(pair->name));
 			pair->attribute = attr->value;
 			pair->type = attr->type;
 			pair->vendorcode = attr->vendorcode;
@@ -598,7 +608,7 @@ int rc_avpair_parse (char *buffer, VALUE_PAIR **first_pair)
 			{
 
 			    case PW_TYPE_STRING:
-				strcpy ((char*) pair->strvalue, valstr);
+				strlcpy ((char*) pair->strvalue, valstr, sizeof(pair->strvalue));
 				pair->lvalue = strlen(valstr);
 				break;
 

--- a/pppd/plugins/radius/avpair.c
+++ b/pppd/plugins/radius/avpair.c
@@ -776,21 +776,30 @@ int rc_avpair_tostr (VALUE_PAIR *pair, char *name, int ln, char *value, int lv)
 
 	    case PW_TYPE_IFID:
 		ptr = pair->strvalue;
-		snprintf(buffer, sizeof (buffer), "%x:%x:%x:%x",
-			 (ptr[0] << 8) + ptr[1], (ptr[2] << 8) + ptr[3],
-			 (ptr[4] << 8) + ptr[5], (ptr[6] << 8) + ptr[7]);
+		if (pair->lvalue >= 8)
+		    snprintf(buffer, sizeof (buffer), "%x:%x:%x:%x",
+			     (ptr[0] << 8) + ptr[1], (ptr[2] << 8) + ptr[3],
+			     (ptr[4] << 8) + ptr[5], (ptr[6] << 8) + ptr[7]);
+		else
+		    slprintf(buffer, sizeof(buffer), "[%.*B]", pair->lvalue, pair->strvalue);
 		strncpy(value, buffer, lv-1);
 		break;
 
 	    case PW_TYPE_IPV6ADDR:
-		inet_ntop(AF_INET6, pair->strvalue, buffer, sizeof (buffer));
+		if (pair->lvalue >= sizeof(struct in6_addr))
+		    inet_ntop(AF_INET6, pair->strvalue, buffer, sizeof (buffer));
+		else
+		    slprintf(buffer, sizeof(buffer), "[%.*B]", pair->lvalue, pair->strvalue);
 		strncpy(value, buffer, lv-1);
 		break;
 
 	    case PW_TYPE_IPV6PREFIX:
-		inet_ntop(AF_INET6, pair->strvalue + 2, buffer, sizeof (buffer));
-		str = buffer + strlen(buffer);
-		snprintf(str, sizeof (buffer) - (str - buffer), "/%d", *(pair->strvalue + 1));
+		if (pair->lvalue >= sizeof(struct in6_addr) + 2) {
+		    inet_ntop(AF_INET6, pair->strvalue + 2, buffer, sizeof (buffer));
+		    str = buffer + strlen(buffer);
+		    snprintf(str, sizeof (buffer) - (str - buffer), "/%d", *(pair->strvalue + 1));
+		} else
+		    slprintf(buffer, sizeof(buffer), "[%.*B]", pair->lvalue, pair->strvalue);
 		strncpy(value, buffer, lv-1);
 		break;
 

--- a/pppd/plugins/radius/avpair.c
+++ b/pppd/plugins/radius/avpair.c
@@ -210,7 +210,7 @@ VALUE_PAIR *rc_avpair_gen (AUTH_HDR *auth)
 				rc_avpair_free(vp);
 				return NULL;
 			}
-			strcpy (pair->name, attr->name);
+			strlcpy (pair->name, attr->name, sizeof(pair->name));
 			pair->attribute = attr->value;
 			pair->vendorcode = VENDOR_NONE;
 			pair->type = attr->type;
@@ -223,6 +223,7 @@ VALUE_PAIR *rc_avpair_gen (AUTH_HDR *auth)
 			    case PW_TYPE_IFID:
 			    case PW_TYPE_IPV6ADDR:
 			    case PW_TYPE_IPV6PREFIX:
+				/* Note attrlen is at most 253 here */
 				memcpy (pair->strvalue, (char *) ptr, (size_t) attrlen);
 				pair->strvalue[attrlen] = '\0';
 				pair->lvalue = attrlen;
@@ -231,6 +232,12 @@ VALUE_PAIR *rc_avpair_gen (AUTH_HDR *auth)
 
 			    case PW_TYPE_INTEGER:
 			    case PW_TYPE_IPADDR:
+				if (attrlen < sizeof(UINT4)) {
+				    error("rc_avpair_gen: %s has short value (%d bytes)",
+					  attr->name, attrlen);
+				    free(pair);
+				    break;
+				}
 				memcpy ((char *) &lvalue, (char *) ptr,
 					sizeof (UINT4));
 				pair->lvalue = ntohl (lvalue);

--- a/pppd/plugins/radius/avpair.c
+++ b/pppd/plugins/radius/avpair.c
@@ -298,7 +298,7 @@ static void rc_extract_vendor_specific_attributes(int attrlen,
 
     /* Set attrlen to length of data */
     attrlen -= 4;
-    for (; attrlen; attrlen -= vlen+2, ptr += vlen) {
+    for (; attrlen >= 2; attrlen -= vlen+2, ptr += vlen) {
 	vtype = *ptr++;
 	vlen = *ptr++;
 	vlen -= 2;
@@ -333,6 +333,10 @@ static void rc_extract_vendor_specific_attributes(int attrlen,
 
 	case PW_TYPE_INTEGER:
 	case PW_TYPE_IPADDR:
+	    if (vlen < sizeof(UINT4)) {
+		free(pair);
+		break;
+	    }
 	    memcpy ((char *) &lvalue, (char *) ptr,
 		    sizeof (UINT4));
 	    pair->lvalue = ntohl (lvalue);

--- a/pppd/plugins/radius/buildreq.c
+++ b/pppd/plugins/radius/buildreq.c
@@ -161,7 +161,7 @@ unsigned char rc_get_seqnbr(void)
  */
 
 int rc_auth(UINT4 client_port, VALUE_PAIR *send, VALUE_PAIR **received,
-	    char *msg, REQUEST_INFO *info)
+	    char *msg, size_t msgspace, REQUEST_INFO *info)
 {
     SERVER *authserver = rc_conf_srv("authserver");
 
@@ -169,7 +169,7 @@ int rc_auth(UINT4 client_port, VALUE_PAIR *send, VALUE_PAIR **received,
 	return (ERROR_RC);
     }
     return rc_auth_using_server(authserver, client_port, send, received,
-				msg, info);
+				msg, msgspace, info);
 }
 
 /*
@@ -188,7 +188,7 @@ int rc_auth_using_server(SERVER *authserver,
 			 UINT4 client_port,
 			 VALUE_PAIR *send,
 			 VALUE_PAIR **received,
-			 char *msg, REQUEST_INFO *info)
+			 char *msg, size_t msgspace, REQUEST_INFO *info)
 {
 	SEND_DATA       data;
 	int		result;
@@ -224,7 +224,7 @@ int rc_auth_using_server(SERVER *authserver,
 		rc_buildreq(&data, PW_ACCESS_REQUEST, authserver->name[i],
 			    authserver->port[i], timeout, retries);
 
-		result = rc_send_server (&data, msg, info);
+		result = rc_send_server (&data, msg, msgspace, info);
 	}
 
 	*received = data.receive_pairs;
@@ -245,7 +245,7 @@ int rc_auth_using_server(SERVER *authserver,
  *
  */
 
-int rc_auth_proxy(VALUE_PAIR *send, VALUE_PAIR **received, char *msg)
+int rc_auth_proxy(VALUE_PAIR *send, VALUE_PAIR **received, char *msg, size_t msgspace)
 {
 	SEND_DATA       data;
 	int		result;
@@ -268,7 +268,7 @@ int rc_auth_proxy(VALUE_PAIR *send, VALUE_PAIR **received, char *msg)
 		rc_buildreq(&data, PW_ACCESS_REQUEST, authserver->name[i],
 			    authserver->port[i], timeout, retries);
 
-		result = rc_send_server (&data, msg, NULL);
+		result = rc_send_server (&data, msg, msgspace, NULL);
 	}
 
 	*received = data.receive_pairs;
@@ -341,7 +341,7 @@ int rc_acct_using_server(SERVER *acctserver,
 		dtime.tv_sec -= start_time.tv_sec;
 		rc_avpair_assign(adt_vp, &dtime.tv_sec, 0);
 
-		result = rc_send_server (&data, msg, NULL);
+		result = rc_send_server (&data, msg, sizeof(msg), NULL);
 	}
 
 	rc_avpair_free(data.receive_pairs);
@@ -398,7 +398,7 @@ int rc_acct_proxy(VALUE_PAIR *send)
 		rc_buildreq(&data, PW_ACCOUNTING_REQUEST, acctserver->name[i],
 			    acctserver->port[i], timeout, retries);
 
-		result = rc_send_server (&data, msg, NULL);
+		result = rc_send_server (&data, msg, sizeof(msg), NULL);
 	}
 
 	rc_avpair_free(data.receive_pairs);
@@ -414,7 +414,7 @@ int rc_acct_proxy(VALUE_PAIR *send)
  *
  */
 
-int rc_check(char *host, unsigned short port, char *msg)
+int rc_check(char *host, unsigned short port, char *msg, size_t msgspace)
 {
 	SEND_DATA       data;
 	int		result;
@@ -440,7 +440,7 @@ int rc_check(char *host, unsigned short port, char *msg)
 	rc_avpair_add(&(data.send_pairs), PW_SERVICE_TYPE, &service_type, 0, VENDOR_NONE);
 
 	rc_buildreq(&data, PW_STATUS_SERVER, host, port, timeout, retries);
-	result = rc_send_server (&data, msg, NULL);
+	result = rc_send_server (&data, msg, msgspace, NULL);
 
 	rc_avpair_free(data.receive_pairs);
 

--- a/pppd/plugins/radius/config.c
+++ b/pppd/plugins/radius/config.c
@@ -98,6 +98,11 @@ static int set_option_srv(char *filename, int line, OPTION *option, char *p)
 	serv->max = 0;
 
 	while ((p = strtok(p, ", \t")) != NULL) {
+		if (serv->max >= SERVER_MAX) {
+			error("%s: line %d: too many servers listed (max %d)",
+			      filename, line, SERVER_MAX);
+			return -1;
+		}
 
 		if ((q = strchr(p,':')) != NULL) {
 			*q = '\0';

--- a/pppd/plugins/radius/radius.c
+++ b/pppd/plugins/radius/radius.c
@@ -63,12 +63,16 @@ static struct avpopt {
 static bool portnummap = 0;
 
 static option_t Options[] = {
-    { "radius-config-file", o_string, &config_file },
-    { "avpair", o_special, add_avp },
+    { "radius-config-file", o_string, &config_file,
+      "Set RADIUS configuration file name", OPT_PRIV },
+    { "avpair", o_special, add_avp,
+      "Add an attribute-value pair to be sent to the RADIUS server", OPT_PRIV },
     { "map-to-ttyname", o_bool, &portnummap,
-	"Set Radius NAS-Port attribute value via libradiusclient library", OPT_PRIO | 1 },
+      "Set Radius NAS-Port attribute value via libradiusclient library",
+      OPT_PRIV | OPT_PRIO | 1 },
     { "map-to-ifname", o_bool, &portnummap,
-	"Set Radius NAS-Port attribute to number as in interface name (Default)", OPT_PRIOSUB | 0 },
+      "Set Radius NAS-Port attribute to number as in interface name (Default)",
+      OPT_PRIV | OPT_PRIOSUB | 0 },
     { NULL }
 };
 

--- a/pppd/plugins/radius/radius.c
+++ b/pppd/plugins/radius/radius.c
@@ -299,9 +299,10 @@ radius_pap_auth(char *user,
     if (rstate.authserver) {
 	result = rc_auth_using_server(rstate.authserver,
 				      rstate.client_port, send,
-				      &received, radius_msg, NULL);
+				      &received, radius_msg, sizeof(radius_msg), NULL);
     } else {
-	result = rc_auth(rstate.client_port, send, &received, radius_msg, NULL);
+	result = rc_auth(rstate.client_port, send, &received,
+			 radius_msg, sizeof(radius_msg), NULL);
     }
 
     if (result == OK_RC) {
@@ -474,10 +475,10 @@ radius_chap_verify(char *user, char *ourname, int id,
     if (rstate.authserver) {
 	result = rc_auth_using_server(rstate.authserver,
 				      rstate.client_port, send,
-				      &received, radius_msg, req_info);
+				      &received, radius_msg, sizeof(radius_msg), req_info);
     } else {
-	result = rc_auth(rstate.client_port, send, &received, radius_msg,
-			 req_info);
+	result = rc_auth(rstate.client_port, send, &received,
+			 radius_msg, sizeof(radius_msg), req_info);
     }
 
     strlcpy(message, radius_msg, message_space);

--- a/pppd/plugins/radius/radiusclient.h
+++ b/pppd/plugins/radius/radiusclient.h
@@ -416,14 +416,14 @@ VALUE_PAIR *rc_avpair_readin(FILE *);
 
 void rc_buildreq(SEND_DATA *, int, char *, unsigned short, int, int);
 unsigned char rc_get_seqnbr(void);
-int rc_auth(UINT4, VALUE_PAIR *, VALUE_PAIR **, char *, REQUEST_INFO *);
+int rc_auth(UINT4, VALUE_PAIR *, VALUE_PAIR **, char *, size_t, REQUEST_INFO *);
 int rc_auth_using_server(SERVER *, UINT4, VALUE_PAIR *, VALUE_PAIR **,
-			 char *, REQUEST_INFO *);
-int rc_auth_proxy(VALUE_PAIR *, VALUE_PAIR **, char *);
+			 char *, size_t, REQUEST_INFO *);
+int rc_auth_proxy(VALUE_PAIR *, VALUE_PAIR **, char *, size_t);
 int rc_acct(UINT4, VALUE_PAIR *);
 int rc_acct_using_server(SERVER *, UINT4, VALUE_PAIR *);
 int rc_acct_proxy(VALUE_PAIR *);
-int rc_check(char *, unsigned short, char *);
+int rc_check(char *, unsigned short, char *, size_t);
 
 /*	clientid.c		*/
 
@@ -459,7 +459,7 @@ UINT4 rc_own_bind_ipaddress(void);
 
 /*	sendserver.c		*/
 
-int rc_send_server(SEND_DATA *, char *, REQUEST_INFO *);
+int rc_send_server(SEND_DATA *, char *, size_t, REQUEST_INFO *);
 
 /*	util.c			*/
 

--- a/pppd/plugins/radius/sendserver.c
+++ b/pppd/plugins/radius/sendserver.c
@@ -18,7 +18,7 @@
 #include <signal.h>
 
 static void rc_random_vector (unsigned char *);
-static int rc_check_reply (AUTH_HDR *, int, char *, unsigned char *, unsigned char);
+static int rc_check_reply (AUTH_HDR *, int, int, char *, unsigned char *, unsigned char);
 
 /*
  * Calculate length occupied by an AVP in the send buffer
@@ -381,9 +381,7 @@ int rc_send_server (SEND_DATA *data, char *msg, REQUEST_INFO *info)
 
 	recv_auth = (AUTH_HDR *)recv_buffer;
 
-	result = rc_check_reply (recv_auth, BUFFER_LEN, secret, vector, data->seq_nbr);
-
-	data->receive_pairs = rc_avpair_gen(recv_auth);
+	result = rc_check_reply (recv_auth, length, BUFFER_LEN, secret, vector, data->seq_nbr);
 
 	close (sockfd);
 	if (info)
@@ -395,6 +393,8 @@ int rc_send_server (SEND_DATA *data, char *msg, REQUEST_INFO *info)
 	memset (secret, '\0', sizeof (secret));
 
 	if (result != OK_RC) return (result);
+
+	data->receive_pairs = rc_avpair_gen(recv_auth);
 
 	*msg = '\0';
 	vp = data->receive_pairs;
@@ -432,7 +432,7 @@ int rc_send_server (SEND_DATA *data, char *msg, REQUEST_INFO *info)
  *
  */
 
-static int rc_check_reply (AUTH_HDR *auth, int bufferlen, char *secret,
+static int rc_check_reply (AUTH_HDR *auth, int datalen, int bufferlen, char *secret,
 			   unsigned char *vector, unsigned char seq_nbr)
 {
 	int             secretlen;
@@ -440,12 +440,17 @@ static int rc_check_reply (AUTH_HDR *auth, int bufferlen, char *secret,
 	unsigned char   calc_digest[AUTH_VECTOR_LEN];
 	unsigned char   reply_digest[AUTH_VECTOR_LEN];
 
+	if (datalen < sizeof(AUTH_HDR)) {
+		error("rc_check_reply: received short RADIUS server response");
+		return BADRESP_RC;
+	}
+
 	totallen = ntohs (auth->length);
 
 	secretlen = strlen (secret);
 
 	/* Do sanity checks on packet length */
-	if ((totallen < 20) || (totallen > 4096))
+	if ((totallen < 20) || totallen > bufferlen || totallen > datalen)
 	{
 		error("rc_check_reply: received RADIUS server response with invalid length");
 		return (BADRESP_RC);

--- a/pppd/plugins/radius/sendserver.c
+++ b/pppd/plugins/radius/sendserver.c
@@ -21,6 +21,39 @@ static void rc_random_vector (unsigned char *);
 static int rc_check_reply (AUTH_HDR *, int, char *, unsigned char *, unsigned char);
 
 /*
+ * Calculate length occupied by an AVP in the send buffer
+ */
+static int rc_pack_length(VALUE_PAIR *vp)
+{
+    int total_length = 1;	/* attribute */
+    int length;
+
+    if (vp->vendorcode != VENDOR_NONE)
+	total_length += 6;	/* length, vendor code, attribute */
+
+    if (vp->vendorcode == VENDOR_NONE && vp->attribute == PW_USER_PASSWORD) {
+	length = vp->lvalue;
+	if (length > AUTH_PASS_LEN)
+	    length = AUTH_PASS_LEN;
+	length = (length + (AUTH_VECTOR_LEN-1)) & ~(AUTH_VECTOR_LEN-1);
+	total_length += length + 1;
+    } else {
+	switch (vp->type) {
+	case PW_TYPE_STRING:
+	    total_length += vp->lvalue + 1;
+	    break;
+	case PW_TYPE_INTEGER:
+	case PW_TYPE_IPADDR:
+	    total_length += sizeof(UINT4) + 1;
+	default:
+	    break;
+	}
+    }
+
+    return total_length;
+}
+
+/*
  * Function: rc_pack_list
  *
  * Purpose: Packs an attribute value pair list into a buffer.
@@ -29,10 +62,10 @@ static int rc_check_reply (AUTH_HDR *, int, char *, unsigned char *, unsigned ch
  *
  */
 
-static int rc_pack_list (VALUE_PAIR *vp, char *secret, AUTH_HDR *auth)
+static int rc_pack_list (VALUE_PAIR *vp, char *secret, AUTH_HDR *auth, int datalen)
 {
     int             length, i, pc, secretlen, padded_length;
-    int             total_length = 0;
+    int             vplen;
     UINT4           lvalue;
     unsigned char   passbuf[MAX(AUTH_PASS_LEN, CHAP_VALUE_LENGTH)];
     unsigned char   md5buf[256];
@@ -42,6 +75,12 @@ static int rc_pack_list (VALUE_PAIR *vp, char *secret, AUTH_HDR *auth)
 
     while (vp != (VALUE_PAIR *) NULL)
 	{
+	    vplen = rc_pack_length(vp);
+	    if ((int)(buf - auth->data) + vplen > datalen) {
+		error("radius: send data would overflow buffer (%d > %d)",
+		      (int)(buf - auth->data) + vplen, datalen);
+		break;
+	    }
 
 	    if (vp->vendorcode != VENDOR_NONE) {
 		*buf++ = PW_VENDOR_SPECIFIC;
@@ -66,7 +105,6 @@ static int rc_pack_list (VALUE_PAIR *vp, char *secret, AUTH_HDR *auth)
 		    *buf++ = length+2;
 		    memcpy(buf, vp->strvalue, (size_t) length);
 		    buf += length;
-		    total_length += length+8;
 		    break;
 		case PW_TYPE_INTEGER:
 		case PW_TYPE_IPADDR:
@@ -76,7 +114,6 @@ static int rc_pack_list (VALUE_PAIR *vp, char *secret, AUTH_HDR *auth)
 		    lvalue = htonl(vp->lvalue);
 		    memcpy(buf, (char *) &lvalue, sizeof(UINT4));
 		    buf += length;
-		    total_length += length+8;
 		    break;
 		default:
 		    break;
@@ -120,8 +157,6 @@ static int rc_pack_list (VALUE_PAIR *vp, char *secret, AUTH_HDR *auth)
 			}
 		    }
 
-		    total_length += padded_length + 2;
-
 		    break;
 #if 0
 		case PW_CHAP_PASSWORD:
@@ -147,7 +182,6 @@ static int rc_pack_list (VALUE_PAIR *vp, char *secret, AUTH_HDR *auth)
 		    for (i = 0; i < CHAP_VALUE_LENGTH; i++) {
 			*buf++ ^= passbuf[i];
 		    }
-		    total_length += CHAP_VALUE_LENGTH + 2;
 
 		    break;
 #endif
@@ -158,7 +192,6 @@ static int rc_pack_list (VALUE_PAIR *vp, char *secret, AUTH_HDR *auth)
 			*buf++ = length + 2;
 			memcpy (buf, vp->strvalue, (size_t) length);
 			buf += length;
-			total_length += length + 2;
 			break;
 
 		    case PW_TYPE_INTEGER:
@@ -167,7 +200,6 @@ static int rc_pack_list (VALUE_PAIR *vp, char *secret, AUTH_HDR *auth)
 			lvalue = htonl (vp->lvalue);
 			memcpy (buf, (char *) &lvalue, sizeof (UINT4));
 			buf += sizeof (UINT4);
-			total_length += sizeof (UINT4) + 2;
 			break;
 
 		    default:
@@ -176,9 +208,15 @@ static int rc_pack_list (VALUE_PAIR *vp, char *secret, AUTH_HDR *auth)
 		    break;
 		}
 	    }
+
 	    vp = vp->next;
 	}
-    return total_length;
+
+    /* Should never happen unless rc_pack_length is buggy */
+    if ((int)(buf - auth->data) > datalen)
+	fatal("radius: BUG! send data buffer overflowed!");
+
+    return buf - auth->data;
 }
 
 /*
@@ -265,12 +303,13 @@ int rc_send_server (SEND_DATA *data, char *msg, REQUEST_INFO *info)
 
 	if (data->code == PW_ACCOUNTING_REQUEST)
 	{
-		total_length = rc_pack_list(data->send_pairs, secret, auth) + AUTH_HDR_LEN;
+		secretlen = strlen (secret);
+		total_length = rc_pack_list(data->send_pairs, secret, auth,
+					    BUFFER_LEN - AUTH_HDR_LEN - secretlen) + AUTH_HDR_LEN;
 
 		auth->length = htons ((unsigned short) total_length);
 
 		memset((char *) auth->vector, 0, AUTH_VECTOR_LEN);
-		secretlen = strlen (secret);
 		memcpy ((char *) auth + total_length, secret, secretlen);
 		rc_md5_calc (vector, (unsigned char *) auth, total_length + secretlen);
 		memcpy ((char *) auth->vector, (char *) vector, AUTH_VECTOR_LEN);
@@ -280,7 +319,8 @@ int rc_send_server (SEND_DATA *data, char *msg, REQUEST_INFO *info)
 		rc_random_vector (vector);
 		memcpy (auth->vector, vector, AUTH_VECTOR_LEN);
 
-		total_length = rc_pack_list(data->send_pairs, secret, auth) + AUTH_HDR_LEN;
+		total_length = rc_pack_list(data->send_pairs, secret, auth,
+					    BUFFER_LEN - AUTH_HDR_LEN) + AUTH_HDR_LEN;
 
 		auth->length = htons ((unsigned short) total_length);
 	}

--- a/pppd/plugins/radius/sendserver.c
+++ b/pppd/plugins/radius/sendserver.c
@@ -226,7 +226,7 @@ static int rc_pack_list (VALUE_PAIR *vp, char *secret, AUTH_HDR *auth, int datal
  *
  */
 
-int rc_send_server (SEND_DATA *data, char *msg, REQUEST_INFO *info)
+int rc_send_server (SEND_DATA *data, char *msg, size_t msgspace, REQUEST_INFO *info)
 {
 	int             sockfd;
 	struct sockaddr salocal;
@@ -402,8 +402,8 @@ int rc_send_server (SEND_DATA *data, char *msg, REQUEST_INFO *info)
 	{
 		if ((vp = rc_avpair_get(vp, PW_REPLY_MESSAGE)))
 		{
-			strcat(msg, (char*) vp->strvalue);
-			strcat(msg, "\n");
+			strlcat(msg, (char*) vp->strvalue, msgspace);
+			strlcat(msg, "\n", msgspace);
 			vp = vp->next;
 		}
 	}


### PR DESCRIPTION
This is a collection of fixes for the radius plugin code, most of which are about checking length values correctly to avoid buffer overflows. Some of these buffer overflows are user-triggerable, that is, caused by command-line options given to pppd, and some of them could be triggered by the RADIUS server sending a badly-formatted RADIUS reply. The first set are handled in part by making all of the radius plugin command-line options privileged, and also by adding suitable length checks. For the second set, suitable length checks are added. But note that the RADIUS server is trusted and the network between pppd and the RADIUS server is assumed to be secure.