### PR TITLE
pppd: allow running without root when CAP_NET_ADMIN is present

### DIFF
--- a/pppd/main.c
+++ b/pppd/main.c
@@ -401,7 +401,11 @@ main(int argc, char *argv[])
     umask(umask(0777) | 022);
 
     uid = getuid();
-    privileged = uid == 0;
+    /* Privileged options come from the invoking user's own authority, so a
+     * pppd that gained privileges from the exec itself must not hand them
+     * to whoever ran it. */
+    privileged = uid == 0 || (uid == geteuid() && !ppp_secure_exec() &&
+                              ppp_privileged());
     slprintf(numbuf, sizeof(numbuf), "%d", uid);
     ppp_script_setenv("ORIG_UID", numbuf, 0);
 
@@ -452,10 +456,11 @@ main(int argc, char *argv[])
     }
 
     /*
-     * Check that we are running as root.
+     * Check that we have the privileges needed to open the ppp device
+     * and configure interfaces.
      */
-    if (geteuid() != 0) {
-	ppp_option_error("must be root to run %s, since it is not setuid-root",
+    if (!ppp_privileged()) {
+	ppp_option_error("%s must be run as root or with CAP_NET_ADMIN",
 		     argv[0]);
 	exit(EXIT_NOT_ROOT);
     }
@@ -1975,9 +1980,11 @@ run_program(char *prog, char * const *args, int must_exist, void (*done)(void *)
     if (ret != 0) {
         fatal("Failed to change directory to '/', %m");
     }
-    ret = setuid(0);		/* set real UID = root */
-    if (ret != 0) {
-        fatal("Failed to set uid, %m");
+    if (geteuid() == 0) {
+	ret = setuid(0);	/* set real UID = root */
+	if (ret != 0) {
+	    fatal("Failed to set uid, %m");
+	}
     }
     ret = setgid(getegid());
     if (ret != 0) {

--- a/pppd/pppd.8
+++ b/pppd/pppd.8
@@ -1324,6 +1324,17 @@ an options file read using the \fIcall\fR option.  If pppd is being
 run by the root user, privileged options can be used without
 restriction.
 .PP
+On Linux, pppd does not have to be run by root: it will also run when
+it has the CAP_NET_ADMIN capability, which is what the kernel requires
+in order to open /dev/ppp and to configure network interfaces.  Pppd
+can thus be run unprivileged under a service manager or in a container
+which grants it that capability, and privileged options can then be
+used without restriction, as for root.  This does not apply to a pppd
+which is setuid-root or setgid, or which has file capabilities set on
+it, and is invoked by a non-privileged user, since there the privilege
+comes from the way the binary is installed rather than from the user
+running it; such a pppd is restricted as described above.
+.PP
 When opening the device, pppd uses either the invoking user's user ID
 or the root UID (that is, 0), depending on whether the device name was
 specified by the user or the system administrator.  If the device name
@@ -1680,7 +1691,9 @@ An error was detected in processing the options given, such as two
 mutually exclusive options being used.
 .TP
 .B 3
-Pppd is not setuid-root and the invoking user is not root.
+Pppd does not have the privileges required to run; that is, it is not
+being run by root, and (on Linux) does not have the CAP_NET_ADMIN
+capability.
 .TP
 .B 4
 The kernel does not support PPP, for example, the PPP kernel driver is
@@ -1741,11 +1754,13 @@ Pppd invokes scripts at various stages in its processing which can be
 used to perform site-specific ancillary processing.  These scripts are
 usually shell scripts, but could be executable code files instead.
 Pppd does not wait for the scripts to finish (except for the net\-init,
-net\-pre\-up and ip\-pre\-up scripts).  The scripts are
-executed as root (with the real and effective user-id set to 0), so
-that they can do things such as update routing tables or run
-privileged daemons.  Be careful that the contents of these scripts do
-not compromise your system's security.  Pppd runs the scripts with
+net\-pre\-up and ip\-pre\-up scripts).  When pppd is running as root,
+the scripts are executed as root (with the real and effective user-id
+set to 0), so that they can do things such as update routing tables or
+run privileged daemons; otherwise they are executed with pppd's own
+user-id and inherit any ambient capabilities it has.  Be careful that
+the contents of these scripts do not compromise your system's
+security.  Pppd runs the scripts with
 standard input, output and error redirected to /dev/null, and with an
 environment that is empty except for some environment variables that
 give information about the link.  The environment variables that pppd

--- a/pppd/pppd.h
+++ b/pppd/pppd.h
@@ -444,6 +444,19 @@ void ppp_script_unsetenv(char *);
 int ppp_check_kernel_support(void);
 
 /*
+ * Test whether we have the privileges needed to open the ppp device
+ * and configure interfaces.
+ */
+int ppp_privileged(void);
+
+/*
+ * Test whether this exec raised our privileges - a setuid or setgid bit
+ * on the binary, or file capabilities - which the kernel grants to
+ * whoever runs it, and not to us on their behalf.
+ */
+int ppp_secure_exec(void);
+
+/*
  * Restore device setting
  */
 void ppp_generic_disestablish(int dev_fd);

--- a/pppd/sys-linux.c
+++ b/pppd/sys-linux.c
@@ -107,6 +107,9 @@
 
 #if !defined(__GLIBC__) || __GLIBC__ >= 2
 #include <asm/types.h>		/* glibc 2 conflicts with linux/types.h */
+#include <sys/syscall.h>
+#include <sys/auxv.h>
+#include <linux/capability.h>
 #include <net/if.h>
 #include <net/if_arp.h>
 #include <net/route.h>
@@ -2849,6 +2852,37 @@ ppp_registered(void)
     close(local_fd);
     close(mfd);
     return ret;
+}
+
+/*
+ * Check whether we have the privileges needed to open the ppp device
+ * and configure interfaces.  The kernel requires CAP_NET_ADMIN to open
+ * /dev/ppp (ppp_open in drivers/net/ppp/ppp_generic.c).
+ */
+int ppp_privileged(void)
+{
+    struct __user_cap_header_struct hdr;
+    struct __user_cap_data_struct data[2];
+
+    if (geteuid() == 0)
+	return 1;
+
+    hdr.version = _LINUX_CAPABILITY_VERSION_3;
+    hdr.pid = 0;
+    if (syscall(SYS_capget, &hdr, data) < 0)
+	return 0;
+
+    return !!(data[CAP_TO_INDEX(CAP_NET_ADMIN)].effective & CAP_TO_MASK(CAP_NET_ADMIN));
+}
+
+/*
+ * Test whether this exec raised our privileges.  The kernel sets AT_SECURE
+ * when a setuid or setgid bit or file capabilities did so, granting them
+ * to whoever runs the binary rather than to us on their behalf.
+ */
+int ppp_secure_exec(void)
+{
+    return getauxval(AT_SECURE) != 0;
 }
 
 /********************************************************************

--- a/pppd/sys-solaris.c
+++ b/pppd/sys-solaris.c
@@ -636,6 +636,26 @@ sys_check_options(void)
 }
 
 /*
+ * ppp_privileged - check whether we have the privileges needed to open
+ * the ppp device and configure interfaces.
+ */
+int
+ppp_privileged(void)
+{
+    return geteuid() == 0;
+}
+
+/*
+ * ppp_secure_exec - Solaris has no AT_SECURE; the euid check in main.c
+ * covers setuid.
+ */
+int
+ppp_secure_exec(void)
+{
+    return 0;
+}
+
+/*
  * ppp_check_kernel_support - check whether the system has any ppp interfaces
  */
 int


### PR DESCRIPTION
pppd refuses to run when `geteuid() != 0`, from the setuid-root era: the message even says "since it is not setuid-root". On Linux the privilege pppd actually needs is a capability, not a uid — the kernel gates `ppp_open()` on `ns_capable(CAP_NET_ADMIN)` (see `drivers/net/ppp/ppp_generic.c`, whose own comment notes this "could (should?) be enforced by the permissions on /dev/ppp") and the interface ioctls require the same. A sandbox that grants that capability (procd/ujail on OpenWrt, systemd) can run pppd fully unprivileged, but the gate stops it before it can try.

Three changes, because clearing the gate alone does not get a non-root pppd to a working link:

**1. The startup gate.** Replace it with `ppp_privileged()`: euid 0, or CAP_NET_ADMIN in the effective set, checked via `capget` so the binary needs no setuid bit and no libcap dependency. Solaris keeps the euid check.

**2. The privileged option flag.** `parse_args()` copies `privileged` into `privileged_option`, and `process_option()` refuses any `OPT_PRIV` option unless it is set. `privileged` was `getuid() == 0`, so an unprivileged pppd that passed the new gate still died on its first privileged option — `ifname` for any caller that names the interface, and `plugin` for pppoe, which is how OpenWrt loads `pppoe.so`. So the flag has to follow the capability too.

It must not follow whatever the *exec* handed over, though. `ppp_privileged()` returns true whenever `geteuid() == 0`, so wiring `privileged` straight to it would set the flag for an unprivileged user invoking a **setuid-root** pppd — exactly the install mode the old message names — and equally for a `setcap cap_net_admin=ep` pppd, where the kernel grants the capability to whoever runs the binary. `plugin` is `OPT_PRIV`, so either would be `dlopen` of an attacker-chosen object with those privileges, and the `OPT_PRIV` file options would additionally skip the `seteuid(getuid())` that `option_open()` does for unprivileged callers. The guard is therefore:

```c
privileged = uid == 0 || (uid == geteuid() && !ppp_secure_exec() && ppp_privileged());
```

`ppp_secure_exec()` is `getauxval(AT_SECURE)` on Linux and 0 on Solaris, where the `uid == geteuid()` term still covers setuid. AT_SECURE is the kernel's own verdict on whether this exec raised privileges: `cap_bprm_creds_from_file()` sets it for a setuid or setgid bit and for file capabilities, and leaves it clear when a non-root process is exec'd with ambient capabilities and no file caps, since `pP' = pA'` and nothing grew. So a sandboxed pppd gets the flag; a setuid-root or setcap pppd invoked by a normal user does not, exactly as before this patch.

**3. `run_program()`.** It re-roots the ip-up/ip-down child with `setuid(0)` before exec. Without `CAP_SETUID` that fails with `EPERM` and is fatal, so the link-up scripts never run under a capability sandbox. Only re-root when already euid 0 (the setuid-installed case); otherwise the child keeps its uid and any ambient capabilities reach the scripts unchanged.

## Testing

Validated on an ipq807x router (aarch64, musl), pppd under procd/ujail on a live PPPoE uplink:

- pppd as an unprivileged user (uid 454) with `CAP_NET_ADMIN`/`CAP_NET_RAW` effective + ambient passes the gate, accepts `ifname` and `plugin pppoe.so`, and brings up a real PPPoE session (v4 + delegated v6)
- the ip-up/ip-down scripts execute as uid 454 and inherit the ambient set
- the same user with an empty capability set exits `EXIT_NOT_ROOT` with `<argv[0]> must be run as root or with CAP_NET_ADMIN`

The three ways a pppd can end up holding CAP_NET_ADMIN were then measured on the built binary — `privileged` is observable, since it flips `must_exist` on the system options file:

| how the capability was obtained | AT_SECURE | `privileged` |
|---|---|---|
| ambient set, unprivileged uid, no file caps (the sandbox case) | 0 | yes |
| `setcap cap_net_admin=ep`, invoked by a normal user | 1 | no |
| setuid-root, invoked by a normal user | 1 | no |

The setuid-root row also reduces to the pre-patch `uid == 0` through the `uid == geteuid()` term, so that case is unchanged by construction either way.


