### PR TITLE
pppd: Erase PAP credentials explicitly

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -94,6 +94,7 @@ AC_CHECK_SIZEOF(unsigned short)
 
 # Checks for library functions.
 AC_CHECK_FUNCS([    \
+    explicit_bzero  \
     fexecve         \
     mmap            \
     logwtmp         \

--- a/pppd/auth.c
+++ b/pppd/auth.c
@@ -1532,7 +1532,7 @@ check_passwd(int unit,
 		free_wordlist(opts);
 	    if (addrs != 0)
 		free_wordlist(addrs);
-	    BZERO(passwd, sizeof(passwd));
+	    ppp_explicit_bzero(passwd, sizeof(passwd));
 	    return ret? UPAP_AUTHACK: UPAP_AUTHNAK;
 	}
     }
@@ -1553,6 +1553,7 @@ check_passwd(int unit,
 
 	if (!ppp_check_access(fd, filename, 0)) {
 	    fclose(f);
+	    ppp_explicit_bzero(passwd, sizeof(passwd));
 	    return UPAP_AUTHNAK;
 	}
 	check_access(fd, filename);
@@ -1617,8 +1618,8 @@ check_passwd(int unit,
 
     if (addrs != NULL)
 	free_wordlist(addrs);
-    BZERO(passwd, sizeof(passwd));
-    BZERO(secret, sizeof(secret));
+    ppp_explicit_bzero(passwd, sizeof(passwd));
+    ppp_explicit_bzero(secret, sizeof(secret));
 
     return ret;
 }
@@ -2310,6 +2311,9 @@ scan_authfile(FILE *f, char *client, char *server,
 	*addrs = addr_list;
     else if (addr_list != NULL)
 	free_wordlist(addr_list);
+
+    ppp_explicit_bzero(word, sizeof(word));
+    ppp_explicit_bzero(lsecret, sizeof(lsecret));
 
     return best_flag;
 }

--- a/pppd/pppd-private.h
+++ b/pppd/pppd-private.h
@@ -336,6 +336,8 @@ void print_string(char *, int,  printer_func, void *);
 				/* Format a string for output */
 ssize_t complete_read(int, void *, size_t);
 				/* read a complete buffer */
+void ppp_explicit_bzero(void *, size_t);
+				/* securely erase a buffer */
 
 /* Procedures exported from auth.c */
 void link_required(int);	  /* we are starting to use the link */

--- a/pppd/upap.c
+++ b/pppd/upap.c
@@ -410,7 +410,7 @@ upap_rauthreq(upap_state *u, u_char *inp, int id, int len)
      */
     retcode = check_passwd(u->us_unit, ruser, ruserlen, rpasswd,
 			   rpasswdlen, &msg);
-    BZERO(rpasswd, rpasswdlen);
+    ppp_explicit_bzero(rpasswd, rpasswdlen);
 
     /*
      * Check remote number authorization.  A plugin may have filled in

--- a/pppd/utils.c
+++ b/pppd/utils.c
@@ -75,6 +75,25 @@ struct buffer_info {
 };
 
 /*
+ * ppp_explicit_bzero - Erase a buffer without allowing the compiler to
+ * optimize the operation away.
+ */
+void
+ppp_explicit_bzero(void *buf, size_t len)
+{
+#ifdef HAVE_EXPLICIT_BZERO
+    explicit_bzero(buf, len);
+#else
+    volatile unsigned char *p = buf;
+
+    while (len != 0) {
+	*p++ = 0;
+	--len;
+    }
+#endif
+}
+
+/*
  * Check that a file descriptor is owned by root, not writable by group or
  * other.
  * If exec is true, check for execute permission, otherwise for read
@@ -1123,4 +1142,3 @@ unlock(void)
 	lock_file[0] = 0;
     }
 }
-

--- a/pppd/utils_utest.c
+++ b/pppd/utils_utest.c
@@ -98,6 +98,20 @@ test_parent_notdir() {
 }
 
 int
+test_explicit_bzero()
+{
+    unsigned char buf[] = { 1, 2, 3, 4 };
+    size_t i;
+
+    ppp_explicit_bzero(buf, sizeof(buf));
+    for (i = 0; i < sizeof(buf); ++i)
+	if (buf[i] != 0)
+	    return -1;
+
+    return 0;
+}
+
+int
 main()
 {
     char *base_dir = strdup("/tmp/ppp_utils_utest.XXXXXX");
@@ -130,6 +144,11 @@ main()
 
     if (test_parent_notdir()) {
 	printf("Creating over a file appeared to work?\n");
+	failure++;
+    }
+
+    if (test_explicit_bzero()) {
+	printf("Could not securely erase buffer\n");
 	failure++;
     }
 


### PR DESCRIPTION
## Summary

This change adds an internal `ppp_explicit_bzero()` helper and uses it to erase PAP credentials after authentication.

The helper calls the system `explicit_bzero()` where available and uses volatile byte stores as a portable fallback.

## Rationale

`BZERO()` expands directly to `memset()`. When it is used to clear a local buffer immediately before the buffer goes out of scope, an optimizing compiler may remove the call as a dead store.

`check_passwd()` currently relies on `BZERO()` to erase both the peer-supplied PAP password and the matching secret read from the secrets file. If those calls are removed, the credentials can remain in stack memory after authentication has completed.

## Changes

- detect the availability of `explicit_bzero()` at configure time;
- add `ppp_explicit_bzero()` with a volatile-store fallback;
- erase the received password in the PAP packet buffer;
- erase the local password and secret copies in `check_passwd()`, including early-return paths;
- erase the temporary `word` and `lsecret` buffers used by `scan_authfile()`;
- add a unit test for the new helper.

The general-purpose `BZERO()` macro is intentionally unchanged because most of its callers use it for ordinary initialization rather than erasing sensitive data.


Found by Linux Verification Center (linuxtesting.org) with SVACE.