### PR TITLE
pppd/EAP-PEAP: Be careful not to overflow outpacket_buf

### DIFF
--- a/pppd/peap.c
+++ b/pppd/peap.c
@@ -68,6 +68,7 @@
 #include "chap_ms.h"
 #include "mppe.h"
 #include "peap.h"
+#include "fsm.h"
 
 #ifdef UNIT_TEST
 #define novm(x)
@@ -260,6 +261,14 @@ static void peap_response(eap_state *esp, u_char id, u_char *buf, int len)
 		peap_len = PEAP_HEADERLEN + PEAP_FRAGMENT_LENGTH_FIELD + len;
 	else
 		peap_len = PEAP_HEADERLEN + len;
+
+	/*
+	 * XXX Dying here is better (just) than overflowing outpacket_buf[].
+	 * There's not much point trying to continue, since the negotiation
+	 * will stall at this point and never complete.
+	 */
+	if (peap_len > MIN(peer_mru[esp->es_unit], PPP_MRU))
+		fatal("BUG! PEAP Response fragmentation not implemented!");
 
 	PUTSHORT(peap_len, outp);
 	PUTCHAR(EAPT_PEAP, outp);


### PR DESCRIPTION
Add a check to ensure that we don't try to copy more data into outpacket_buf[] when sending a PEAP Response packet than will fit. Ideally we would implement fragmentation and send the data in several packets, but we don't have that logic.  Rather than overflow the buffer and corrupt memory, this causes pppd to die with a call to fatal(), because there is little point trying to continue given that the negotiation is going to stall indefinitely at that point.

This is a fix for the vulnerability described in CVE-2026-75883.
