### PR TITLE
plugins/pppol2tp: Improve length checks in pppol2tp_lcp_snoop()

### DIFF
--- a/pppd/plugins/pppol2tp/pppol2tp.c
+++ b/pppd/plugins/pppol2tp/pppol2tp.c
@@ -357,7 +357,7 @@ static void pppol2tp_lcp_snoop(unsigned char *buf, int len, int incoming)
 	len -= 2;
 
 	/* Unreasonably short frame?? */
-	if (len <= 0) return;
+	if (len < 4) return;
 
 	/* Look for Configure-Ack or Configure-Reject code */
 	if (buf[0] != CONFACK && buf[0] != CONFREJ) return;
@@ -373,7 +373,7 @@ static void pppol2tp_lcp_snoop(unsigned char *buf, int len, int incoming)
 	len = lcp_pkt_len - 4;
 	buf += 4;
 
-	while (len > 0) {
+	while (len >= 2) {
 		/* Pull off an option */
 		opt = buf[0];
 		opt_len = buf[1];


### PR DESCRIPTION
The LCP snoop code in pppol2tp could potentially read two bytes beyond the actual packet length if a malformed LCP packet was received, though subsequent checks prevented any action being taken based on the contents of those bytes.  This strengthens the length checks to ensure that we don't read them.