### PR TITLE
EAP-TLS bug fixes and improvements

### DIFF
--- a/pppd/eap-tls.c
+++ b/pppd/eap-tls.c
@@ -973,7 +973,7 @@ int eaptls_send(struct eaptls_session *ets, bool is_server, u_char ** outp)
 {
     bool first = 0;
     int size;
-    u_char fromtls[65536];
+    u_char dummy[256];
     int res;
     u_char *start;
 
@@ -983,9 +983,9 @@ int eaptls_send(struct eaptls_session *ets, bool is_server, u_char ** outp)
     {
         if (!ets->alert_sent) {
 	    /* This serves mainly to advance the TLS handshake process. */
-            res = SSL_read(ets->ssl, fromtls, sizeof(fromtls));
+            res = SSL_read(ets->ssl, dummy, sizeof(dummy));
 	    if (res >= 0)
-		dbglog("got %d bytes from SSL_read: %.*B", MIN(res, 20), fromtls);
+		dbglog("got %d bytes from SSL_read: %.*B", MIN(res, 20), dummy);
         }
 
 	/*
@@ -1008,9 +1008,9 @@ int eaptls_send(struct eaptls_session *ets, bool is_server, u_char ** outp)
         /*
          * Read from ssl 
          */
-        if ((res = BIO_read(ets->from_ssl, fromtls, 65536)) == -1)
-        {
-            warn("EAP-TLS send: No data from BIO_read");
+	res = BIO_pending(ets->from_ssl);
+	if (res <= 0) {
+            warn("EAP-TLS send: No data available");
             return 1;
         }
 
@@ -1020,7 +1020,14 @@ int eaptls_send(struct eaptls_session *ets, bool is_server, u_char ** outp)
         if (!ets->data)
             fatal("EAP-TLS: memory allocation error in eaptls_send\n");
 
-        BCOPY(fromtls, ets->data, ets->datalen);
+        if ((res = BIO_read(ets->from_ssl, ets->data, ets->datalen)) != ets->datalen) {
+	    if (res < 0)
+		error("EAP-TLS send: error in BIO_read");
+	    else
+		error("EAP-TLS send: short read from SSL BIO (%d != %d)",
+		      res, ets->datalen);
+            return 1;
+        }
 
         ets->offset = 0;
         first = 1;

--- a/pppd/eap-tls.c
+++ b/pppd/eap-tls.c
@@ -684,6 +684,18 @@ int eaptls_init_ssl_server(eap_state * esp)
     if (!ets->ctx)
         goto fail;
 
+#ifdef TLS1_3_VERSION
+    /*
+     * RFC9190 says that EAP-TLS with TLS v1.3 requires the server
+     * to send at least one session ticket.  In fact OpenSSL defaults
+     * to sending two, so this reduces it to one.
+     */
+    if (max_tls_version && strcmp(max_tls_version, "1.3") == 0 &&
+	!SSL_CTX_set_num_tickets(ets->ctx, 1)) {
+	warn("EAP-TLS server could not request 1 session ticket");
+    }
+#endif
+
     if (!(ets->ssl = SSL_new(ets->ctx)))
         goto fail;
 
@@ -709,6 +721,7 @@ int eaptls_init_ssl_server(eap_state * esp)
     SSL_set_accept_state(ets->ssl);
 
     ets->tls_v13 = 0;
+    ets->sbyte_sent = 0;
 
     ets->data = NULL;
     ets->datalen = 0;
@@ -778,6 +791,7 @@ int eaptls_init_ssl_client(eap_state * esp)
     SSL_set_connect_state(ets->ssl);
 
     ets->tls_v13 = 0;
+    ets->sbyte_rcvd = 0;
 
     ets->data = NULL;
     ets->datalen = 0;
@@ -810,10 +824,14 @@ void eaptls_free_session(struct eaptls_session *ets)
 
 int eaptls_is_init_finished(struct eaptls_session *ets)
 {
-    if (ets->ssl && SSL_is_init_finished(ets->ssl))
-    {
-        if (ets->tls_v13) 
-            return have_session_ticket;
+    if (ets->ssl && SSL_is_init_finished(ets->ssl)) {
+	/* don't return finished if there is still data to send */
+	if (BIO_pending(ets->from_ssl) > 0) {
+	    dbglog("SSL init finished but data pending");
+	    return 0;
+	}
+        if (ets->tls_v13)
+            return ets->sbyte_rcvd;
         else
             return 1;
     }
@@ -829,7 +847,8 @@ int eaptls_receive(struct eaptls_session *ets, u_char * inp, int len)
 {
     u_char flags;
     u_int tlslen = 0;
-    u_char dummy[65536];
+    u_char dummy[1024];
+    int res;
 
     if (len < 1) {
         warn("EAP-TLS: received no or invalid data");
@@ -839,14 +858,21 @@ int eaptls_receive(struct eaptls_session *ets, u_char * inp, int len)
     GETCHAR(flags, inp);
     len--;
 
-    if (flags & EAP_TLS_FLAGS_LI && len > 4) {
+    if (flags & EAP_TLS_FLAGS_LI) {
         /*
-         * LenghtIncluded flag set -> this is the first packet of a message
+         * LengthIncluded flag set -> this is the first packet of a message
         */
 
         /*
          * the first 4 octets are the length of the EAP-TLS message
          */
+	if (len < 4) {
+	    warn("EAP-TLS: received malformed data, len=%d", len);
+	    free(ets->data);
+	    ets->data = NULL;
+	    return 1;
+	}
+
         GETLONG(tlslen, inp);
         len -= 4;
 
@@ -888,13 +914,6 @@ int eaptls_receive(struct eaptls_session *ets, u_char * inp, int len)
     else
         ets->frag = 0;
 
-    if (len < 0) {
-        warn("EAP-TLS: received malformed data");
-        free(ets->data);
-        ets->data = NULL;
-        return 1;
-    }
-
     if (len + ets->datalen > ets->tlslen) {
         warn("EAP-TLS: received data > TLS message length");
         free(ets->data);
@@ -921,7 +940,20 @@ int eaptls_receive(struct eaptls_session *ets, u_char * inp, int len)
         if (BIO_write(ets->into_ssl, ets->data, ets->datalen) == -1)
             tls_log_sslerr();
 
-        SSL_read(ets->ssl, dummy, 65536);
+	/*
+	 * This serves mainly to advance the TLS handshake process,
+	 * but also gives us the 0x00 byte for the protected success
+	 * indication with TLS 1.3.
+	 */
+        res = SSL_read(ets->ssl, dummy, sizeof(dummy));
+	if (res > 0) {
+	    dbglog("SSL_read in eaptls_receive gave %d bytes: %.*B",
+		   res, MIN(res, 20), dummy);
+	    if (dummy[0] == 0 && !ets->sbyte_rcvd) {
+		dbglog("EAP-TLS received protected success indication");
+		ets->sbyte_rcvd = true;
+	    }
+	}
 
         free(ets->data);
         ets->data = NULL;
@@ -937,7 +969,7 @@ int eaptls_receive(struct eaptls_session *ets, u_char * inp, int len)
  * At each call we control if there is buffered data and send a 
  * packet of mtu bytes.
  */
-int eaptls_send(struct eaptls_session *ets, u_char ** outp)
+int eaptls_send(struct eaptls_session *ets, bool is_server, u_char ** outp)
 {
     bool first = 0;
     int size;
@@ -949,10 +981,29 @@ int eaptls_send(struct eaptls_session *ets, u_char ** outp)
 
     if (!ets->data)
     {
-        if(!ets->alert_sent)
-        {
-            res = SSL_read(ets->ssl, fromtls, 65536);
+        if (!ets->alert_sent) {
+	    /* This serves mainly to advance the TLS handshake process. */
+            res = SSL_read(ets->ssl, fromtls, sizeof(fromtls));
+	    if (res >= 0)
+		dbglog("got %d bytes from SSL_read: %.*B", MIN(res, 20), fromtls);
         }
+
+	/*
+	 * With TLS v1.3, the server has to send a single 0x00 byte
+	 * through the encrypted channel (i.e. as application data)
+	 * as a success indication once the TLS handshaking is complete.
+	 */
+	if (is_server && ets->tls_v13 && !ets->sbyte_sent &&
+	    SSL_is_init_finished(ets->ssl)) {
+	    char success = 0;
+	    dbglog("SSL init finished in eaptls_send, sending success byte");
+	    res = SSL_write(ets->ssl, &success, 1);
+	    if (res <= 0)
+		error("EAP-TLS: Failed to send protected success indication (err=%d)",
+		      SSL_get_error(ets->ssl, res));
+	    else
+		ets->sbyte_sent = true;
+	}
 
         /*
          * Read from ssl 
@@ -1003,7 +1054,7 @@ int eaptls_send(struct eaptls_session *ets, u_char ** outp)
     INCPTR(size, *outp);
 
     /*
-     * Copy the packet in retransmission buffer 
+     * Copy the packet into retransmission buffer 
      */
     BCOPY(start, &ets->rtx[0], *outp - start);
     ets->rtx_len = *outp - start;
@@ -1128,7 +1179,7 @@ ssl_msg_callback(int write_p, int version, int content_type,
 #endif
 #ifdef SSL3_MT_ENCRYPTED_EXTENSIONS
             case SSL3_MT_ENCRYPTED_EXTENSIONS:
-                strcat(string,"Encryped Extensions");
+                strcat(string,"Encrypted Extensions");
                 break;
 #endif
             case SSL3_MT_CERTIFICATE:
@@ -1175,6 +1226,11 @@ ssl_msg_callback(int write_p, int version, int content_type,
                         strcat(string, "Unknown version");
                 }
                 break;
+#ifdef SSL3_MT_COMPRESSED_CERTIFICATE
+	    case SSL3_MT_COMPRESSED_CERTIFICATE:
+		strcat(string, "Compressed Certificate");
+		break;
+#endif
             default:
                 sprintf( string, "Handshake: Unknown SSL3 code received: %d", code );
         }

--- a/pppd/eap-tls.h
+++ b/pppd/eap-tls.h
@@ -55,6 +55,8 @@ struct eaptls_session
     int tlslen;                 /* total length of tls data */
     bool frag;                  /* packet is fragmented */
     bool tls_v13;               /* whether we've negotiated TLSv1.3 */
+    bool sbyte_sent;		/* whether the 0x00 success byte has been sent */
+    bool sbyte_rcvd;		/* whether the 0x00 success byte has been received */
     SSL_CTX *ctx;
     SSL *ssl;                   /* ssl connection */
     BIO *from_ssl;
@@ -80,7 +82,7 @@ void eaptls_free_session(struct eaptls_session *ets);
 int eaptls_is_init_finished(struct eaptls_session *ets);
 
 int eaptls_receive(struct eaptls_session *ets, u_char * inp, int len);
-int eaptls_send(struct eaptls_session *ets, u_char ** outp);
+int eaptls_send(struct eaptls_session *ets, bool is_server, u_char ** outp);
 void eaptls_retransmit(struct eaptls_session *ets, u_char ** outp);
 
 int get_eaptls_secret(int unit, char *client, char *server,

--- a/pppd/eap.c
+++ b/pppd/eap.c
@@ -337,14 +337,13 @@ eap_figure_next_state(eap_state *esp, int status)
 	case eapTlsSend:
 		ets = (struct eaptls_session *) esp->es_server.ea_session;
 
-		if(ets->frag)
+		if (ets->frag)
 			esp->es_server.ea_state = eapTlsRecvAck;
-		else
-			if(SSL_is_init_finished(ets->ssl))
-				esp->es_server.ea_state = eapTlsRecvClient;
-			else
-				/* JJK Add "TLS empty record" message here ??? */
-				esp->es_server.ea_state = eapTlsRecv;
+		else if (SSL_is_init_finished(ets->ssl)) {
+			dbglog("SSL init finished in next_state");
+			esp->es_server.ea_state = eapTlsRecvClient;
+		} else
+			esp->es_server.ea_state = eapTlsRecv;
 		break;
 
 	case eapTlsSendAck:
@@ -568,18 +567,15 @@ eap_send_request(eap_state *esp)
 		break;
 
 	case eapTlsSend:
-		eaptls_send(esp->es_server.ea_session, &outp);
+	case eapTlsSendAlert:
+		if (eaptls_send(esp->es_server.ea_session, true, &outp))
+			return;
 		eap_figure_next_state(esp, 0);
 		break;
 
 	case eapTlsSendAck:
 		PUTCHAR(EAPT_TLS, outp);
 		PUTCHAR(0, outp);
-		eap_figure_next_state(esp, 0);
-		break;
-
-	case eapTlsSendAlert:
-		eaptls_send(esp->es_server.ea_session, &outp);
 		eap_figure_next_state(esp, 0);
 		break;
 #endif /* PPP_WITH_EAPTLS */
@@ -872,8 +868,10 @@ eap_tls_response(eap_state *esp, u_char id)
 	*/
 	if(id == esp->es_client.ea_id)
 		eaptls_retransmit(esp->es_client.ea_session, &outp);
-	else
-		eaptls_send(esp->es_client.ea_session, &outp);
+	else {
+		if (eaptls_send(esp->es_client.ea_session, false, &outp))
+			return;
+	}
 
 	outlen = (outp - outpacket_buf) - PPP_HDRLEN;
 	PUTSHORT(outlen, lenloc);
@@ -1167,6 +1165,7 @@ eap_request(eap_state *esp, u_char *inp, int id, int len)
 			}
 
 			if(ets->alert_recv) {
+				dbglog("EAP-TLS got alert, acking");
 				eap_tls_sendack(esp, id);
 				esp->es_client.ea_state = eapTlsRecvFailure;
 				break;

--- a/pppd/eap.c
+++ b/pppd/eap.c
@@ -1804,11 +1804,9 @@ eap_response(eap_state *esp, u_char *inp, int id, int len)
 static void
 eap_success(eap_state *esp, u_char *inp, int id, int len)
 {
-	if (esp->es_client.ea_state != eapOpen && !eap_client_active(esp)
-#ifdef PPP_WITH_EAPTLS
-		&& esp->es_client.ea_state != eapTlsRecvSuccess
-#endif /* PPP_WITH_EAPTLS */
-		) {
+	if (esp->es_client.ea_state == eapOpen)
+		return;
+	if (!eap_client_active(esp)) {
 		dbglog("EAP unexpected success message in state %s (%d)",
 		    eap_state_name(esp->es_client.ea_state),
 		    esp->es_client.ea_state);
@@ -1851,7 +1849,7 @@ eap_failure(eap_state *esp, u_char *inp, int id, int len)
 	/*
 	 * Ignore failure messages if we're not open
 	 */
-	if (esp->es_client.ea_state <= eapClosed)
+	if (esp->es_client.ea_state <= eapClosed || esp->es_client.ea_state == eapBadAuth)
 		return;
 
 	if (!eap_client_active(esp)) {

--- a/pppd/eap.c
+++ b/pppd/eap.c
@@ -156,6 +156,7 @@ eap_init(int unit)
 	esp->es_server.ea_timeout = EAP_DEFTIMEOUT;
 	esp->es_server.ea_maxrequests = EAP_DEFTRANSMITS;
 	esp->es_server.ea_id = (u_char)(drand48() * 0x100);
+	esp->es_server.ea_typeacked = 0;
 	esp->es_client.ea_timeout = EAP_DEFREQTIME;
 	esp->es_client.ea_maxrequests = EAP_DEFALLOWREQ;
 #ifdef PPP_WITH_EAPTLS
@@ -283,19 +284,23 @@ eap_figure_next_state(eap_state *esp, int status)
 
 	case eapIdentify:
 		if (status != 0) {
+			/* received a Nak */
 			esp->es_server.ea_state = eapBadAuth;
 			break;
 		}
 #ifdef PPP_WITH_EAPTLS
+		/* Do EAP-TLS if we don't have a CHAP secret for the peer */
                 if (!get_secret(esp->es_unit, esp->es_server.ea_peer,
                     esp->es_server.ea_name, secret, &secret_len, 1)) {
 
 			esp->es_server.ea_state = eapTlsStart;
+			esp->es_server.ea_authtype = EAPT_TLS;
 			break;
 		}
 #endif /* PPP_WITH_EAPTLS */
 
 		esp->es_server.ea_state = eapMD5Chall;
+		esp->es_server.ea_authtype = EAPT_MD5CHAP;
 		break;
 
 #ifdef PPP_WITH_EAPTLS
@@ -1395,6 +1400,22 @@ eap_response(eap_state *esp, u_char *inp, int id, int len)
 	GETCHAR(typenum, inp);
 	len--;
 
+	/* Check that the peer replied with the type we expect */
+	if (typenum > EAPT_NAK && typenum != esp->es_server.ea_authtype) {
+		dbglog("EAP: discarding response with wrong auth type %d != %d",
+		       typenum, esp->es_server.ea_authtype);
+		return;
+	}
+	if (typenum > EAPT_NAK && (esp->es_server.ea_state <= eapClosed ||
+				   esp->es_server.ea_state >= eapOpen)) {
+		dbglog("EAP: discarding response with auth type %d in state %s (%d)",
+		       typenum, eap_state_name(esp->es_server.ea_state),
+		       esp->es_server.ea_state);
+		return;
+	}
+	if (typenum > EAPT_NAK)
+		esp->es_server.ea_typeacked = 1;
+
 	switch (typenum) {
 	case EAPT_IDENTITY:
 		if (esp->es_server.ea_state != eapIdentify) {
@@ -1436,9 +1457,8 @@ eap_response(eap_state *esp, u_char *inp, int id, int len)
 			break;
 
 		case eapTlsRecvAck:
-			if(len > 1) {
-				dbglog("EAP-TLS ACK with extra data");
-			}
+			if (len > 1)
+				error("EAP-TLS ACK with extra data (%d bytes)", len-1);
 			eap_figure_next_state(esp, 0);
 			break;
 
@@ -1469,6 +1489,11 @@ eap_response(eap_state *esp, u_char *inp, int id, int len)
 			eap_send_failure(esp);
 			break;
 
+		case eapOpen:
+		case eapBadAuth:
+			dbglog("EAP-TLS dropping spurious client response");
+			break;
+
 		default:
 			eap_figure_next_state(esp, 1);
 			break;
@@ -1481,6 +1506,16 @@ eap_response(eap_state *esp, u_char *inp, int id, int len)
 		break;
 
 	case EAPT_NAK:
+		if (esp->es_server.ea_state >= eapOpen) {
+			dbglog("EAP ignoring spurious Nak after auth finished");
+			return;
+		}
+		if (esp->es_server.ea_typeacked) {
+			/* Peer cannot Nak after sending Response to our auth */
+			dbglog("EAP ignoring bogus Nak, peer agreed to %d",
+			       esp->es_server.ea_authtype);
+			return;
+		}
 		if (len < 1 || inp[0] == 0) {
 			info("EAP: Nak Response with no suggested protocol");
 			eap_figure_next_state(esp, 1);
@@ -1490,8 +1525,8 @@ eap_response(eap_state *esp, u_char *inp, int id, int len)
 		GETCHAR(vallen, inp);
 		len--;
 
-		if (!explicit_remote && esp->es_server.ea_state == eapIdentify){
-			/* Peer cannot Nak Identify Request */
+		if (esp->es_server.ea_state == eapIdentify){
+			/* Peer cannot Nak Identity Request */
 			eap_figure_next_state(esp, 1);
 			break;
 		}
@@ -1499,12 +1534,14 @@ eap_response(eap_state *esp, u_char *inp, int id, int len)
 		switch (vallen) {
 		case EAPT_MD5CHAP:
 			esp->es_server.ea_state = eapMD5Chall;
+			esp->es_server.ea_authtype = EAPT_MD5CHAP;
 			break;
 
 #ifdef PPP_WITH_EAPTLS
 			/* Send EAP-TLS start packet */
 		case EAPT_TLS:
 			esp->es_server.ea_state = eapTlsStart;
+			esp->es_server.ea_authtype = EAPT_TLS;
 			break;
 #endif /* PPP_WITH_EAPTLS */
 
@@ -1519,6 +1556,7 @@ eap_response(eap_state *esp, u_char *inp, int id, int len)
 				break;
 			}
 			esp->es_server.ea_state = eapMSCHAPv2Chall;
+			esp->es_server.ea_authtype = EAPT_MSCHAPV2;
 			break;
 #endif /* PPP_WITH_CHAPMS */
 
@@ -1921,6 +1959,8 @@ eap_printpkt(u_char *inp, int inlen,
 	if (len < EAP_HEADERLEN || len > inlen) {
 		printer(arg, " <bad length=%d>", len);
 		return (0);
+	} else {
+		printer(arg, " len=%d", len);
 	}
 	len -= EAP_HEADERLEN;
 	switch (code) {

--- a/pppd/eap.c
+++ b/pppd/eap.c
@@ -130,6 +130,7 @@ struct protent eap_protent = {
 
 /* Local forward declarations. */
 static void eap_server_timeout (void *arg);
+static void eap_failure(eap_state *esp, u_char *inp, int id, int len);
 
 /*
  * Convert EAP state code to printable string for debug.
@@ -980,15 +981,16 @@ eap_request(eap_state *esp, u_char *inp, int id, int len)
 	PPP_MD_CTX *mdctx;
 	u_char hash[MD5_DIGEST_LENGTH];
 	int hashlen = MD5_DIGEST_LENGTH;
+	bool ok;
 #ifdef PPP_WITH_EAPTLS
 	u_char flags;
 	struct eaptls_session *ets = esp->es_client.ea_session;
 #endif /* PPP_WITH_EAPTLS */
 
 	/*
-	 * Ignore requests if we're not open
+	 * Ignore requests if we're not active
 	 */
-	if (esp->es_client.ea_state <= eapClosed)
+	if (!eap_client_active(esp))
 		return;
 
 	/*
@@ -1015,6 +1017,16 @@ eap_request(eap_state *esp, u_char *inp, int id, int len)
 
 	GETCHAR(typenum, inp);
 	len--;
+
+	if (typenum > EAPT_NAK) {
+		if (esp->es_client.ea_state == eapListen)
+			esp->es_client.ea_authtype = typenum;
+		else if (typenum != esp->es_client.ea_authtype) {
+			warn("EAP: dropping EAP-Request for type %d after seeing %d",
+			     typenum, esp->es_client.ea_authtype);
+			return;
+		}
+	}
 
 	switch (typenum) {
 	case EAPT_IDENTITY:
@@ -1080,6 +1092,7 @@ eap_request(eap_state *esp, u_char *inp, int id, int len)
 			break;
 		}
 
+		ok = false;
 		mdctx = PPP_MD_CTX_new();
 		if (mdctx != NULL) {
 			if (PPP_DigestInit(mdctx, PPP_md5())) {
@@ -1088,20 +1101,22 @@ eap_request(eap_state *esp, u_char *inp, int id, int len)
 					if (PPP_DigestUpdate(mdctx, secret, secret_len)) {
 						BZERO(secret, sizeof(secret));
 						if (PPP_DigestUpdate(mdctx, inp, vallen)) {
-							if (PPP_DigestFinal(mdctx, hash, &hashlen)) {
-								eap_chap_response(esp, id, hash, esp->es_client.ea_name,
-										esp->es_client.ea_namelen);
-								PPP_MD_CTX_free(mdctx);
-								break;
-							}
+							if (PPP_DigestFinal(mdctx, hash, &hashlen))
+								ok = true;
 						}
 					}
 				}
 			}
 			PPP_MD_CTX_free(mdctx);
 		}
-		dbglog("EAP: MD5 checksum calculation failed");
-		eap_send_nak(esp, id, 0);
+		if (ok) {
+			eap_chap_response(esp, id, hash, esp->es_client.ea_name,
+					  esp->es_client.ea_namelen);
+			esp->es_client.ea_state = eapAuthRecv;
+		} else {
+			error("EAP: MD5 checksum calculation failed");
+			eap_send_nak(esp, id, 0);
+		}
 		break;
 
 #ifdef PPP_WITH_EAPTLS
@@ -1219,7 +1234,7 @@ eap_request(eap_state *esp, u_char *inp, int id, int len)
 	    /* If MSCHAPv2 digest was not found, NAK the packet */
 	    if (!esp->es_client.digest) {
 		error("EAP MSCHAPv2 not supported");
-		eap_send_nak(esp, id, EAPT_SRP);
+		eap_send_nak(esp, id, EAPT_MD5CHAP);
 		return;
 	    }
 
@@ -1267,7 +1282,7 @@ eap_request(eap_state *esp, u_char *inp, int id, int len)
 		if (!get_secret(esp->es_unit, esp->es_client.ea_name,
 		    rhostname, secret, &secret_len, 0)) {
 		    dbglog("EAP: no CHAP secret for auth to %q", rhostname);
-		    eap_send_nak(esp, id, EAPT_SRP);
+		    eap_send_nak(esp, id, 0);
 		    break;
 		}
 		esp->es_client.ea_namelen = strlen(esp->es_client.ea_name);
@@ -1278,12 +1293,17 @@ eap_request(eap_state *esp, u_char *inp, int id, int len)
 			challenge, secret, secret_len, NULL);
 
 		eap_chapv2_response(esp, id, chapid, response, esp->es_client.ea_name, esp->es_client.ea_namelen);
+		esp->es_client.ea_state = eapAuthRecv;
 		break;
 	    }
 	    case CHAP_SUCCESS: {
 
 		/* Check response for mutual authentication */
 		u_char status = CHAP_FAILURE;
+		if (esp->es_client.ea_state == eapListen) {
+			warn("EAP-MSCHAPv2 discarding Success without Challenge first");
+			break;
+		}
 		if (esp->es_client.digest->check_success(chapid, inp, len) == 1) {
 		     info("Chap authentication succeeded! %.*v", len, inp);
 		     status = CHAP_SUCCESS;
@@ -1298,12 +1318,13 @@ eap_request(eap_state *esp, u_char *inp, int id, int len)
 
 		u_char status = CHAP_FAILURE;
 		eap_send_response(esp, id, EAPT_MSCHAPV2, &status, sizeof(status));
-		goto client_failure; /* force termination */
+		/* force termination */
+		eap_failure(esp, inp, id, 0);
 	    }
 	    default:
 
                 error("EAP: received invalid MSCHAPv2 packet, invalid or unsupported opcode: %d", opcode);
-		eap_send_nak(esp, id, EAPT_SRP);
+		eap_send_nak(esp, id, 0);
 	    }
 
 	    break;
@@ -1325,15 +1346,23 @@ eap_request(eap_state *esp, u_char *inp, int id, int len)
 
 		/* Process the PEAP packet */
 		if (peap_process(esp, id, inp, len)) {
-			eap_send_nak(esp, id, EAPT_TLS);
-		}
+			if (esp->es_client.ea_state = eapListen)
+				eap_send_nak(esp, id, EAPT_TLS);
+			else {
+				/* If we've responded to PEAP requests, we can't
+				   ask for something different now, so just fail. */
+				eap_failure(esp, inp, id, 0);
+			}
+			peap_finish(&esp->ea_peap);
+		} else
+			esp->es_client.ea_state = eapAuthRecv;
 
 		break;
 #endif // PPP_WITH_PEAP
 
 	default:
 		info("EAP: unknown authentication type %d; Naking", typenum);
-		eap_send_nak(esp, id, EAPT_SRP);
+		eap_send_nak(esp, id, EAPT_MD5CHAP);
 		break;
 	}
 
@@ -1342,14 +1371,6 @@ eap_request(eap_state *esp, u_char *inp, int id, int len)
 		TIMEOUT(eap_client_timeout, (void *)esp,
 		    esp->es_client.ea_timeout);
 	}
-	return;
-
-client_failure:
-	esp->es_client.ea_state = eapBadAuth;
-	if (esp->es_client.ea_timeout > 0) {
-		UNTIMEOUT(eap_client_timeout, (void *)esp);
-	}
-	esp->es_client.ea_session = NULL;
 }
 
 /*

--- a/pppd/eap.h
+++ b/pppd/eap.h
@@ -110,17 +110,12 @@ enum eap_state_code {
 	"TlsSendAlert", "TlsRecvAlertAck" , "TlsRecvSuccess", "TlsRecvFailure", \
 	"MD5Chall", "MSCHAPv2Chall", "Open", "BadAuth"
 
-#ifdef PPP_WITH_EAPTLS
-#define	eap_client_active(esp)	((esp)->es_client.ea_state != eapInitial &&\
-				 (esp)->es_client.ea_state != eapPending &&\
-				 (esp)->es_client.ea_state != eapClosed)
-#else
-#define eap_client_active(esp)	((esp)->es_client.ea_state == eapListen)
-#endif /* PPP_WITH_EAPTLS */
+#define eap_client_active(esp)	((esp)->es_client.ea_state > eapClosed &&\
+				 (esp)->es_client.ea_state < eapOpen)
 
 #define	eap_server_active(esp)	\
 	((esp)->es_server.ea_state >= eapIdentify && \
-	 (esp)->es_server.ea_state <= eapMD5Chall)
+	 (esp)->es_server.ea_state <= eapMSCHAPv2Chall)
 
 struct eap_auth {
 	char *ea_name;		/* Our name */

--- a/pppd/eap.h
+++ b/pppd/eap.h
@@ -86,6 +86,7 @@ enum eap_state_code {
 	eapPending,	/* Waiting for LCP (no timer) */
 	eapClosed,	/* Authentication not in use */
 	eapListen,	/* Client ready (and timer running) */
+	eapAuthRecv,	/* Receive further requests in a sequence */
 	eapIdentify,	/* EAP Identify sent */
 	eapTlsStart,	/* Send EAP-TLS start packet */
 	eapTlsRecv,	/* Receive EAP-TLS tls data */
@@ -104,7 +105,7 @@ enum eap_state_code {
 };
 
 #define	EAP_STATES	\
-	"Initial", "Pending", "Closed", "Listen", "Identify", \
+	"Initial", "Pending", "Closed", "Listen", "AuthRecv", "Identify", \
 	"TlsStart", "TlsRecv", "TlsSendAck", "TlsSend", "TlsRecvAck", "TlsRecvClient",\
 	"TlsSendAlert", "TlsRecvAlertAck" , "TlsRecvSuccess", "TlsRecvFailure", \
 	"MD5Chall", "MSCHAPv2Chall", "Open", "BadAuth"

--- a/pppd/eap.h
+++ b/pppd/eap.h
@@ -128,6 +128,8 @@ struct eap_auth {
 	unsigned char *ea_skey;	/* Shared encryption key */
 	int ea_timeout;		/* Time to wait (for retransmit/fail) */
 	int ea_maxrequests;	/* Max Requests allowed */
+	short ea_authtype;	/* EAP type we're using */
+	short ea_typeacked;	/* set when peer agreed to authtype */
 	unsigned short ea_namelen;	/* Length of our name */
 	unsigned short ea_peerlen;	/* Length of peer's name */
 	enum eap_state_code ea_state;

--- a/pppd/tls.c
+++ b/pppd/tls.c
@@ -345,6 +345,13 @@ int tls_set_version(SSL_CTX *ctx, const char *max_version)
         return -1;
     }
 
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+    /* OpenSSL v3 disables TLS 1.0 and 1.1 by default unless we do this... */
+    if (tls_version <= TLS1_1_VERSION) {
+	dbglog("setting security level 0");
+	SSL_CTX_set_security_level(ctx, 0);
+    }
+#endif
     return 0;
 }
 


### PR DESCRIPTION
This updates EAP-TLS code to make it compliant with RFC9190, i.e., work correctly with TLS v1.3, and to fix a nasty potential use-after-free and double-free which is triggerable by the peer sending an extra Ack after it gets the Success packet.