### PR TITLE
pppd/EAP-TLS: Fix use-after-free bug in eapTlsRecvClient state

### DIFF
--- a/pppd/eap.c
+++ b/pppd/eap.c
@@ -1173,6 +1173,7 @@ eap_request(eap_state *esp, u_char *inp, int id, int len)
 				eaptls_gen_mppe_keys(ets, 1);
 #endif
 				eaptls_free_session(ets);
+				esp->es_client.ea_session = NULL;
 				eap_tls_sendack(esp, id);
 				esp->es_client.ea_state = eapTlsRecvSuccess;
 				break;
@@ -1443,24 +1444,24 @@ eap_response(eap_state *esp, u_char *inp, int id, int len)
 
 		case eapTlsRecvClient:
 			/* Receive authentication response from client */
-			if (len > 0) {
-				GETCHAR(flags, inp);
-
-				if(len == 1 && !flags) {	/* Ack = ok */
-#ifdef PPP_WITH_MPPE
-					eaptls_gen_mppe_keys( esp->es_server.ea_session, 0 );
-#endif
-					eap_send_success(esp);
-				}
-				else {			/* failure */
-					warn("Server authentication failed");
-					eap_send_failure(esp);
-				}
-			}
-			else
+			if (len <= 0) {
 				warn("Bogus EAP-TLS packet received from client");
+				break;
+			}
+			GETCHAR(flags, inp);
+			if(len == 1 && !flags) {	/* Ack = ok */
+#ifdef PPP_WITH_MPPE
+				eaptls_gen_mppe_keys( esp->es_server.ea_session, 0 );
+#endif
+				eap_send_success(esp);
+				esp->es_server.ea_state = eapOpen;
+			} else {			/* failure */
+				warn("EAP-TLS Server authentication failed");
+				eap_send_failure(esp);
+			}
 
 			eaptls_free_session(esp->es_server.ea_session);
+			esp->es_server.ea_session = NULL;
 
 			break;
 


### PR DESCRIPTION
When pppd is authenticating the peer using EAP-TLS, after the TLS handshake finishes successfully, the EAP state machine goes into state eapTlsRecvClient waiting for an EAP-TLS Ack from the peer indicating that mutual authentication was successful.  When that Ack arrives, we send an EAP-Success packet and free the TLS session data structure, but stay in eapTlsRecvClient state.

Normally the client doesn't then send any further EAP packets.  But a malicious client that sent another EAP-TLS Ack with a suitable ID value (equal to one more than the ID on the EAP-Success packet) would cause the code to redo eaptls_gen_mppe_keys() using the freed session pointer, and then free the TLS session data structure again, leading to memory corruption and pppd crashing with SIGSEGV.

The same effect would happen if the peer sent a malformed short EAP-TLS packet followed by a legitimate EAP-TLS Ack.

This fixes it by (a) going to eapOpen state when the EAP-Success packet is sent (as in the CHAP-MD5 case), (b) setting the session pointer to NULL after freeing it (both in the server and the client case), and (c) not freeing the state when a malformed packet is received.

Thanks to the Kimi Security Team for finding and reporting this.