### PR TITLE
plugins: handle allocation failures in radius and winbind

### DIFF
--- a/pppd/plugins/radius/radius.c
+++ b/pppd/plugins/radius/radius.c
@@ -183,10 +183,18 @@ plugin_init(void)
 static int
 add_avp(char **argv)
 {
-    struct avpopt *p = malloc(sizeof(struct avpopt));
+    struct avpopt *p = malloc(sizeof(*p));
+
+    if (p == NULL) {
+	novm("RADIUS avpair option");
+    }
 
     /* Append to a list of vp's for later parsing */
     p->vpstr = strdup(*argv);
+    if (p->vpstr == NULL) {
+	free(p);
+	novm("RADIUS avpair option value");
+    }
     p->next = avpopt;
     avpopt = p;
 

--- a/pppd/plugins/radius/radrealms.c
+++ b/pppd/plugins/radius/radrealms.c
@@ -53,8 +53,13 @@ lookup_realm(char const *user,
     int line = 0;
     
     auths = (SERVER *) malloc(sizeof(SERVER));
-    auths->max = 0;
     accts = (SERVER *) malloc(sizeof(SERVER));
+    if (auths == NULL || accts == NULL) {
+	free(auths);
+	free(accts);
+	novm("RADIUS realm server lists");
+    }
+    auths->max = 0;
     accts->max = 0;
     
     realm = strrchr(user, '@');

--- a/pppd/plugins/winbind.c
+++ b/pppd/plugins/winbind.c
@@ -213,6 +213,10 @@ char * base64_encode(const char *data)
 	char *result = malloc(output_len); /* get us plenty of space */
 	unsigned int bits;
 
+	if (result == NULL) {
+		novm("base64 output buffer");
+	}
+
 	for (; len >= 3; len -= 3) {
 		bits = (ptr[0] << 16) + (ptr[1] << 8) + ptr[2];
 		ptr += 3;


### PR DESCRIPTION
Static analysis found unchecked `malloc()` and `strdup()` results in the RADIUS and winbind plugins. Allocation failures could therefore result in NULL pointer dereferences.

This change:

- checks the base64 output buffer allocation in the winbind plugin;
- checks both RADIUS realm server-list allocations before initialization;
- checks the structure and string allocations used for `avpair` options;
- frees partially allocated RADIUS objects before invoking `novm()`.

Out-of-memory conditions remain fatal through the existing `novm()` handler.

Found by Linux Verification Center (linuxtesting.org) with SVACE.