### PR TITLE
pppd: use OS randomness for authentication challenges

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -57,7 +57,9 @@ AC_CHECK_HEADERS([  \
     stdarg.h        \
     sys/dlpi.h      \
     sys/ioctl.h     \
+    sys/random.h    \
     sys/socket.h    \
+    sys/syscall.h   \
     sys/time.h      \
     sys/uio.h       \
     time.h          \
@@ -96,6 +98,7 @@ AC_CHECK_SIZEOF(unsigned short)
 AC_CHECK_FUNCS([    \
     explicit_bzero  \
     fexecve         \
+    getrandom       \
     mmap            \
     logwtmp         \
     strerror])

--- a/pppd/Makefile.am
+++ b/pppd/Makefile.am
@@ -54,6 +54,7 @@ pppd_include_HEADERS = \
 
 # Headers to be distributed, but not installed in /usr/include/pppd
 noinst_HEADERS = \
+    auth-random.h \
     chap-md5.h \
     crypto-priv.h \
     eap-tls.h \
@@ -66,6 +67,7 @@ noinst_HEADERS = \
 
 pppd_SOURCES = \
     auth.c \
+    auth-random.c \
     ccp.c \
     chap-md5.c \
     chap.c \

--- a/pppd/Makefile.am
+++ b/pppd/Makefile.am
@@ -26,6 +26,26 @@ utest_utils_LDFLAGS =
 
 check_PROGRAMS += utest_utils
 
+utest_auth_random_SOURCES = auth_random_utest.c
+utest_auth_random_CPPFLAGS = -I$(srcdir)
+utest_auth_random_device_SOURCES = auth_random_utest.c
+utest_auth_random_device_CPPFLAGS = -I$(srcdir) -DTEST_NO_GETRANDOM
+check_PROGRAMS += utest_auth_random utest_auth_random_device
+
+utest_auth_protocol_SOURCES = auth_protocol_utest.c utils.c crypto_ms.c
+utest_auth_protocol_CPPFLAGS = -I$(srcdir) -DUNIT_TEST $(OPENSSL_INCLUDES)
+utest_auth_protocol_LDADD = libppp_crypto.la
+check_PROGRAMS += utest_auth_protocol
+
+if LINUX
+utest_auth_random_syscall_SOURCES = auth_random_utest.c
+utest_auth_random_syscall_CPPFLAGS = -I$(srcdir) -DTEST_RAW_GETRANDOM
+check_PROGRAMS += utest_auth_random_syscall
+utest_auth_random_no_header_SOURCES = auth_random_utest.c
+utest_auth_random_no_header_CPPFLAGS = -I$(srcdir) -DTEST_NO_RANDOM_H
+check_PROGRAMS += utest_auth_random_no_header
+endif
+
 pkgconfigdir   = $(libdir)/pkgconfig
 pkgconfig_DATA = pppd.pc
 
@@ -193,6 +213,13 @@ pppd_LIBS += $(SYSTEMD_LIBS)
 endif
 
 pppd_LDADD = $(pppd_LIBS)
+
+# Use the daemon's actual option tables and parser without starting a link.
+utest_auth_options_SOURCES = $(pppd_SOURCES) auth_options_utest.c
+utest_auth_options_CPPFLAGS = $(pppd_CPPFLAGS) -Dmain=pppd_main
+utest_auth_options_LDFLAGS = $(pppd_LDFLAGS)
+utest_auth_options_LDADD = $(pppd_LDADD)
+check_PROGRAMS += utest_auth_options
 
 EXTRA_DIST = \
     ppp.pam

--- a/pppd/auth-random.c
+++ b/pppd/auth-random.c
@@ -1,0 +1,130 @@
+/*
+ * Randomness for authentication challenges.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <errno.h>
+#include <fcntl.h>
+#include <string.h>
+#include <unistd.h>
+#ifdef HAVE_SYS_RANDOM_H
+#include <sys/random.h>
+#endif
+#if defined(__linux__) && defined(HAVE_SYS_SYSCALL_H)
+#include <sys/syscall.h>
+#endif
+
+#include "pppd-private.h"
+#include "auth-random.h"
+#include "magic.h"
+
+/* Use OS interfaces with explicit error returns. arc4random_buf() has no
+ * recoverable error result or nonblocking flag, so it cannot implement our
+ * policy of failing authentication when randomness is unavailable.
+ */
+/* Linux kernels can provide getrandom even when libc has no wrapper. */
+#if defined(__linux__) && defined(SYS_getrandom)
+#ifndef GRND_NONBLOCK
+#define GRND_NONBLOCK 0x0001
+#endif
+#define auth_getrandom(buf, len) syscall(SYS_getrandom, buf, len, GRND_NONBLOCK)
+#endif
+#if defined(HAVE_GETRANDOM) && defined(HAVE_SYS_RANDOM_H) && defined(GRND_NONBLOCK)
+#undef auth_getrandom
+#define auth_getrandom(buf, len) getrandom(buf, len, GRND_NONBLOCK)
+#endif
+
+#ifndef O_CLOEXEC
+#define O_CLOEXEC 0
+#endif
+
+bool allow_insecure_random = false;
+
+/* No weak fallback here: errno describes why the OS source failed. */
+static int
+secure_random_bytes(unsigned char *buf, int len)
+{
+    int fd, saved_errno;
+    ssize_t n;
+
+#ifdef auth_getrandom
+    while (len > 0) {
+        /* Small requests also accommodate platforms with per-call limits. */
+        errno = 0;
+        n = auth_getrandom(buf, len > 256 ? 256 : len);
+        if (n > 0) {
+            buf += n;
+            len -= n;
+            continue;
+        }
+        if (errno == EINTR)
+            continue;
+        if (errno == ENOSYS)
+            break;
+        if (n == 0 && errno == 0)
+            errno = EIO;
+        /* In particular, do not bypass RNG initialization after EAGAIN. */
+        return 0;
+    }
+    if (len == 0)
+        return 1;
+#endif
+
+    /* Portable fallback. Older Linux kernels do not report RNG readiness
+     * through this device; its early-boot limitation is documented in pppd.8.
+     */
+    do {
+        fd = open("/dev/urandom", O_RDONLY | O_NONBLOCK | O_CLOEXEC);
+    } while (fd < 0 && errno == EINTR);
+    if (fd < 0)
+        return 0;
+
+    while (len > 0) {
+        n = read(fd, buf, len > 256 ? 256 : len);
+        if (n > 0) {
+            buf += n;
+            len -= n;
+        } else if (n < 0 && errno == EINTR) {
+            continue;
+        } else {
+            saved_errno = n == 0 ? EIO : errno;
+            close(fd);
+            errno = saved_errno;
+            return 0;
+        }
+    }
+    close(fd);
+    return 1;
+}
+
+int
+auth_random_bytes(unsigned char *buf, int len)
+{
+    int saved_errno;
+
+    if (len < 0 || (buf == NULL && len != 0)) {
+        errno = EINVAL;
+        return 0;
+    }
+    if (len == 0 || secure_random_bytes(buf, len))
+        return 1;
+
+    saved_errno = errno;
+    if (allow_insecure_random) {
+        warn("Secure authentication randomness unavailable (%s); using insecure PRNG",
+             strerror(saved_errno));
+        /* Replace the entire buffer, including any partial OS result. */
+        random_bytes(buf, len);
+        return 1;
+    }
+
+    memset(buf, 0, len);
+    error("Cannot obtain secure authentication randomness: %s",
+          strerror(saved_errno));
+    errno = saved_errno;
+    return 0;
+}

--- a/pppd/auth-random.h
+++ b/pppd/auth-random.h
@@ -1,0 +1,13 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Randomness for authentication challenges. */
+#ifndef PPP_AUTH_RANDOM_H
+#define PPP_AUTH_RANDOM_H
+
+#include <stdbool.h>
+
+extern bool allow_insecure_random;
+
+/* Return 1 only when all bytes have been filled; on failure return 0. */
+int auth_random_bytes(unsigned char *buf, int len);
+
+#endif /* PPP_AUTH_RANDOM_H */

--- a/pppd/auth.c
+++ b/pppd/auth.c
@@ -109,6 +109,7 @@
 #endif
 
 #include "pppd-private.h"
+#include "auth-random.h"
 #include "options.h"
 #include "fsm.h"
 #include "lcp.h"
@@ -313,6 +314,9 @@ static void check_maxoctets (void *);
  * Authentication-related options.
  */
 struct option auth_options[] = {
+    { "allow-insecure-random", o_bool, &allow_insecure_random,
+      "Allow insecure authentication randomness if the OS source fails",
+      OPT_PRIV | 1 },
     { "auth", o_bool, &auth_required,
       "Require authentication from peer", OPT_PRIO | 1 },
     { "noauth", o_bool, &auth_required,

--- a/pppd/auth_options_utest.c
+++ b/pppd/auth_options_utest.c
@@ -1,0 +1,39 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Link the daemon with its entry point renamed; exercise its real options. */
+#include "config.h"
+#include "pppd-private.h"
+#include "auth-random.h"
+#undef NDEBUG
+#include <assert.h>
+#include <string.h>
+
+#undef main
+int main(void)
+{
+    char name[] = "allow-insecure-random";
+    char *args[] = { name };
+    struct wordlist word = { NULL, name };
+
+    progname = "utest_auth_options";
+    assert(!allow_insecure_random);
+
+    /* Peer-specific options from an untrusted secrets entry cannot opt out. */
+    assert(!options_from_list(&word, 0));
+    assert(!allow_insecure_random);
+
+    privileged = 0;
+    assert(!parse_args(1, args));
+    assert(!allow_insecure_random);
+
+    privileged = 1;
+    assert(parse_args(1, args));
+    assert(allow_insecure_random);
+
+    /* Privilege must still be checked after an earlier privileged setting. */
+    privileged = 0;
+    assert(!parse_args(1, args));
+    assert(allow_insecure_random);
+
+    puts("Authentication random option privilege tests passed");
+    return 0;
+}

--- a/pppd/auth_protocol_utest.c
+++ b/pppd/auth_protocol_utest.c
@@ -1,0 +1,286 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Run authentication state machines without a PPP device or a remote peer. */
+#include "config.h"
+#include "pppd-private.h"
+#undef HAVE_CONFIG_H
+#undef NDEBUG
+#include <assert.h>
+#include <string.h>
+
+/* TLS transport is replaced below; authentication code runs unchanged. */
+#undef PPP_WITH_EAPTLS
+#undef PPP_WITH_MPPE
+/* UNIT_TEST stubs logging in utils.c; here it would enable embedded test mains. */
+#undef UNIT_TEST
+
+/* Include the implementations to inspect state and invoke timer callbacks. */
+#include "chap.c"
+#include "chap-md5.c"
+#ifdef PPP_WITH_CHAPMS
+#include "chap_ms.c"
+#endif
+#include "eap.c"
+
+#ifdef PPP_WITH_PEAP
+#include <openssl/ssl.h>
+static int test_SSL_read(SSL *ssl, void *buf, int len);
+#define SSL_read test_SSL_read
+#include "peap.c"
+#undef SSL_read
+
+char *max_tls_version, *ca_path, *cacert_file, *crl_dir, *crl_file;
+int tls_init(void) { assert(0); return 0; }
+const SSL_METHOD *tls_method(void) { assert(0); return NULL; }
+int tls_set_opts(SSL_CTX *ctx) { assert(0); return 0; }
+int tls_set_version(SSL_CTX *ctx, const char *version) { assert(0); return 0; }
+int tls_set_verify(SSL_CTX *ctx, int depth) { assert(0); return 0; }
+int tls_set_ca(SSL_CTX *ctx, const char *dir, const char *file) { assert(0); return 0; }
+int tls_set_crl(SSL_CTX *ctx, const char *dir, const char *file) { assert(0); return 0; }
+int tls_set_verify_info(SSL *ssl, const char *peer, const char *cert,
+                        bool client, struct tls_info **out) { assert(0); return 0; }
+void tls_free_verify_info(struct tls_info **info) { assert(0); }
+
+static const u_char inner_request[22] = {
+    EAPT_MSCHAPV2, CHAP_CHALLENGE, 7, 0, 21, 16
+};
+static int test_SSL_read(SSL *ssl, void *buf, int len)
+{
+    assert(len >= sizeof(inner_request));
+    memcpy(buf, inner_request, sizeof(inner_request));
+    return sizeof(inner_request);
+}
+#endif
+
+int debug, error_count, unsuccess;
+int peer_mru[NUM_PPP] = { PPP_MRU };
+void novm(const char *msg) { assert(0); abort(); }
+bool explicit_remote, session_mgmt;
+char remote_name[MAXNAMELEN], devnam[1024];
+u_char outpacket_buf[PPP_MRU + PPP_HDRLEN];
+static int random_ok, random_calls, packets, peer_failures, client_failures;
+static int timers, cancellations;
+static u_char last_packet[PPP_MRU + PPP_HDRLEN];
+static int last_length;
+
+int auth_random_bytes(unsigned char *buf, int len)
+{
+    ++random_calls;
+    memset(buf, random_ok ? 0xa5 : 0, len);
+    return random_ok;
+}
+
+void output(int unit, unsigned char *pkt, int len)
+{
+    assert(len <= sizeof(last_packet));
+    memcpy(last_packet, pkt, len);
+    last_length = len;
+    ++packets;
+}
+void auth_peer_fail(int unit, int protocol) { ++peer_failures; }
+void auth_withpeer_fail(int unit, int protocol) { ++client_failures; }
+void auth_peer_success(int unit, int protocol, int flavor, char *name, int len)
+{ assert(0); }
+void auth_withpeer_success(int unit, int protocol, int flavor) { assert(0); }
+void ppp_timeout(ppp_timer_cb func, void *arg, int sec, int usec) { ++timers; }
+void ppp_untimeout(void (*func)(void *), void *arg) { ++cancellations; }
+void ppp_add_options(option_t *opts) {}
+int get_secret(int unit, char *client_name, char *server_name, char *secret,
+               int *len, int am_server)
+{
+    strcpy(secret, "clientPass");
+    *len = strlen(secret);
+    return 1;
+}
+int auth_number(void) { return 1; }
+int session_start(const int flags, const char *user, const char *passwd,
+                  const char *tty, char **msg) { return 1; }
+
+static void reset(void)
+{
+    random_ok = 0;
+    random_calls = packets = peer_failures = client_failures = 0;
+    timers = cancellations = 0;
+    last_length = 0;
+    chap_lowerdown(0);
+    chap_digests = NULL;
+    chap_init(0);
+    eap_init(0);
+#ifdef PPP_WITH_CHAPMS
+    chapms2_response_cache_size = chapms2_response_cache_next_index = 0;
+#endif
+    cancellations = 0;
+}
+
+static void test_chap_server(int digest)
+{
+    reset();
+    chap_lowerup(0);
+    chap_auth_peer(0, "server", digest);
+    assert(random_calls == 1 && peer_failures == 1);
+    assert(packets == 0 && timers == 0);
+    assert((server.flags & (AUTH_FAILED | AUTH_DONE)) == (AUTH_FAILED | AUTH_DONE));
+    assert(!(server.flags & (CHALLENGE_VALID | TIMEOUT_PENDING)));
+    random_ok = 1;
+    chap_server_timeout(&server);
+    assert(random_calls == 1 && packets == 0 && peer_failures == 1);
+
+    reset();
+    random_ok = 1;
+    chap_lowerup(0);
+    chap_auth_peer(0, "server", digest);
+    assert(packets == 1 && peer_failures == 0);
+    assert(server.flags & CHALLENGE_VALID);
+    assert(last_packet[PPP_HDRLEN] == CHAP_CHALLENGE);
+    /* Retransmission reuses the challenge and must not request randomness. */
+    random_ok = 0;
+    chap_server_timeout(&server);
+    assert(random_calls == 1 && packets == 2 && peer_failures == 0);
+}
+
+static void test_eap_server(enum eap_state_code state)
+{
+    eap_state *esp = &eap_states[0];
+    reset();
+    esp->es_server.ea_name = "server";
+    esp->es_server.ea_namelen = 6;
+    esp->es_server.ea_state = state;
+    eap_send_request(esp);
+    assert(random_calls == 1 && peer_failures == 1);
+    assert(esp->es_server.ea_state == eapBadAuth);
+    assert(esp->es_challen == 0 && timers == 0);
+    /* EAP may send Failure, but never an authentication challenge. */
+    assert(packets == 1 && last_length == PPP_HDRLEN + EAP_HEADERLEN);
+    assert(last_packet[PPP_HDRLEN] == EAP_FAILURE);
+
+    reset();
+    random_ok = 1;
+    esp->es_server.ea_name = "server";
+    esp->es_server.ea_namelen = 6;
+    esp->es_server.ea_state = state;
+    eap_send_request(esp);
+    assert(random_calls == 1 && packets == 1 && peer_failures == 0);
+    assert(last_packet[PPP_HDRLEN] == EAP_REQUEST);
+}
+
+#ifdef PPP_WITH_CHAPMS
+static void test_chap_client(void)
+{
+    u_char challenge[17] = { 16 };
+    reset();
+    chap_lowerup(0);
+    chap_auth_with_peer(0, "User", CHAP_MICROSOFT_V2);
+    timers = 0;
+    chap_respond(&client, 7, challenge, sizeof(challenge));
+    assert(random_calls == 1 && client_failures == 1 && packets == 0);
+    assert(client.flags & AUTH_FAILED);
+    assert(!(client.flags & TIMEOUT_PENDING));
+    assert(chapms2_response_cache_size == 0);
+    random_ok = 1;
+    chap_respond(&client, 8, challenge, sizeof(challenge));
+    assert(random_calls == 1 && packets == 0 && client_failures == 1);
+
+    reset();
+    random_ok = 1;
+    chap_lowerup(0);
+    chap_auth_with_peer(0, "User", CHAP_MICROSOFT_V2);
+    chap_respond(&client, 7, challenge, sizeof(challenge));
+    assert(packets == 1 && client_failures == 0);
+    assert(last_packet[PPP_HDRLEN] == CHAP_RESPONSE);
+    assert(chapms2_response_cache_size == 1);
+    random_ok = 0;
+    chap_respond(&client, 7, challenge, sizeof(challenge));
+    assert(random_calls == 1 && packets == 2 && client_failures == 0);
+}
+
+static void test_eap_client(void)
+{
+    eap_state *esp = &eap_states[0];
+    u_char request[22] = { EAPT_MSCHAPV2, CHAP_CHALLENGE, 7, 0, 21, 16 };
+    reset();
+    eap_authwithpeer(0, "User");
+    timers = 0;
+    eap_request(esp, request, 9, sizeof(request));
+    assert(random_calls == 1 && client_failures == 1);
+    assert(packets == 0 && timers == 0 && cancellations == 1);
+    assert(esp->es_client.ea_state == eapBadAuth);
+    assert(chapms2_response_cache_size == 0);
+
+    reset();
+    random_ok = 1;
+    eap_authwithpeer(0, "User");
+    eap_request(esp, request, 9, sizeof(request));
+    assert(random_calls == 1 && client_failures == 0 && packets == 1);
+    assert(last_packet[PPP_HDRLEN] == EAP_RESPONSE);
+}
+#endif
+
+#ifdef PPP_WITH_PEAP
+static void test_peap_client(void)
+{
+    eap_state *esp = &eap_states[0];
+    u_char request[] = { EAPT_PEAP, 0 };
+    u_char in_buf[TLS_RECORD_MAX_SIZE], out_buf[TLS_RECORD_MAX_SIZE];
+    struct peap_state *psm;
+    int i, out_len;
+
+    /* A local failure must neither send a response nor negotiate a downgrade,
+     * including when this was the first PEAP request.
+     */
+    for (i = 0; i < 2; ++i) {
+        reset();
+        eap_authwithpeer(0, "User");
+        if (i) {
+            esp->es_client.ea_state = eapAuthRecv;
+            esp->es_client.ea_authtype = EAPT_PEAP;
+        }
+        psm = calloc(1, sizeof(*psm));
+        assert(psm);
+        psm->phase = PEAP_PHASE_2;
+        psm->in_buf = in_buf;
+        psm->out_buf = out_buf;
+        psm->chap = chap_find_digest(CHAP_MICROSOFT_V2);
+        esp->ea_peap = psm;
+        timers = 0;
+        eap_request(esp, request, 9, sizeof(request));
+        assert(random_calls == 1 && client_failures == 1);
+        assert(packets == 0 && timers == 0 && cancellations == 1);
+        assert(esp->es_client.ea_state == eapBadAuth);
+        assert(esp->ea_peap == NULL && chapms2_response_cache_size == 0);
+    }
+
+    reset();
+    random_ok = 1;
+    eap_authwithpeer(0, "User");
+    psm = calloc(1, sizeof(*psm));
+    assert(psm);
+    psm->chap = chap_find_digest(CHAP_MICROSOFT_V2);
+    psm->out_buf = out_buf;
+    esp->ea_peap = psm;
+    memcpy(in_buf, inner_request, sizeof(inner_request));
+    out_len = sizeof(out_buf);
+    peap_do_inner_eap(in_buf, sizeof(inner_request), esp, 9, out_buf, &out_len);
+    assert(out_len > 0 && out_buf[0] == EAPT_MSCHAPV2 && out_buf[1] == CHAP_RESPONSE);
+    assert(random_calls == 1 && chapms2_response_cache_size == 1);
+    peap_finish(&esp->ea_peap);
+}
+#endif
+
+int main(void)
+{
+    assert(PPP_crypto_init());
+    test_chap_server(CHAP_MD5);
+    test_eap_server(eapMD5Chall);
+#ifdef PPP_WITH_CHAPMS
+    test_chap_server(CHAP_MICROSOFT);
+    test_chap_server(CHAP_MICROSOFT_V2);
+    test_chap_client();
+    test_eap_server(eapMSCHAPv2Chall);
+    test_eap_client();
+#endif
+#ifdef PPP_WITH_PEAP
+    test_peap_client();
+#endif
+    PPP_crypto_deinit();
+    puts("Authentication protocol failure tests passed");
+    return 0;
+}

--- a/pppd/auth_random_utest.c
+++ b/pppd/auth_random_utest.c
@@ -1,0 +1,289 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Exercise the real random-source selection code with scripted OS results. */
+#include "config.h"
+#ifdef TEST_NO_RANDOM_H
+#undef HAVE_SYS_RANDOM_H
+#endif
+#undef NDEBUG
+#include <assert.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+#ifdef HAVE_SYS_RANDOM_H
+#include <sys/random.h>
+#endif
+#ifdef HAVE_SYS_SYSCALL_H
+#include <sys/syscall.h>
+#endif
+#include "pppd-private.h"
+#undef HAVE_CONFIG_H
+
+struct result { int count; int err; };
+static struct result get_results[8], read_results[8];
+static int get_count, read_count, opens, closes, weak_calls, warnings, errors;
+static int syscall_count;
+static int open_errno, open_eintr;
+
+static ssize_t
+next_result(struct result *results, int *index, void *buf, size_t len,
+            unsigned char value)
+{
+    struct result r;
+    assert(*index < 8);
+    r = results[(*index)++];
+    errno = r.err;
+    if (r.count > 0) {
+        assert((size_t)r.count <= len);
+        memset(buf, value, r.count);
+    }
+    return r.count;
+}
+
+static ssize_t
+test_getrandom(void *buf, size_t len, unsigned int flags)
+{
+#ifdef GRND_NONBLOCK
+    assert(flags == GRND_NONBLOCK);
+#elif defined(__linux__)
+    assert(flags == 0x0001); /* Linux syscall ABI without the libc header. */
+#else
+    assert(0); /* This platform will exercise the device fallback instead. */
+#endif
+    return next_result(get_results, &get_count, buf, len, 0xa5);
+}
+
+static long
+test_syscall(long number, void *buf, size_t len, unsigned int flags)
+{
+#ifdef SYS_getrandom
+    assert(number == SYS_getrandom);
+#else
+    assert(0);
+#endif
+    ++syscall_count;
+    return test_getrandom(buf, len, flags);
+}
+
+static int
+test_open(const char *path, int flags)
+{
+    int expected_flags = O_RDONLY | O_NONBLOCK;
+
+    assert(strcmp(path, "/dev/urandom") == 0);
+#ifdef O_CLOEXEC
+    expected_flags |= O_CLOEXEC;
+#endif
+    assert(flags == expected_flags);
+    ++opens;
+    if (open_eintr) {
+        open_eintr = 0;
+        errno = EINTR;
+        return -1;
+    }
+    errno = open_errno;
+    return open_errno ? -1 : 42;
+}
+
+static ssize_t
+test_read(int fd, void *buf, size_t len)
+{
+    assert(fd == 42);
+    return next_result(read_results, &read_count, buf, len, 0xb6);
+}
+
+static int
+test_close(int fd)
+{
+    assert(fd == 42);
+    ++closes;
+    errno = EBADF; /* Cleanup must preserve the original read error. */
+    return 0;
+}
+
+void warn(const char *fmt, ...) { ++warnings; }
+void error(const char *fmt, ...) { ++errors; }
+void random_bytes(unsigned char *buf, int len)
+{
+    ++weak_calls;
+    memset(buf, 0x5a, len);
+}
+
+#ifdef TEST_NO_GETRANDOM
+#undef HAVE_GETRANDOM
+#undef HAVE_SYS_RANDOM_H
+#undef HAVE_SYS_SYSCALL_H
+#undef SYS_getrandom
+#elif defined(TEST_RAW_GETRANDOM)
+#undef HAVE_GETRANDOM
+#endif
+
+#define getrandom test_getrandom
+#define syscall test_syscall
+#define open test_open
+#define read test_read
+#define close test_close
+#include "auth-random.c"
+#undef getrandom
+#undef syscall
+#undef open
+#undef read
+#undef close
+
+static void
+reset(void)
+{
+    memset(get_results, 0, sizeof(get_results));
+    memset(read_results, 0, sizeof(read_results));
+    get_count = read_count = opens = closes = weak_calls = warnings = errors = 0;
+    syscall_count = 0;
+    open_errno = open_eintr = 0;
+    allow_insecure_random = 0;
+}
+
+static void
+expect_bytes(unsigned char *buf, int len, unsigned char value)
+{
+    int i;
+    for (i = 0; i < len; ++i)
+        assert(buf[i] == value);
+}
+
+static void
+use_device(void)
+{
+    reset();
+    get_results[0] = (struct result){ -1, ENOSYS };
+}
+
+int
+main(void)
+{
+    unsigned char buf[300];
+
+    reset();
+    assert(auth_random_bytes(NULL, 0));
+    assert(!auth_random_bytes(NULL, 1) && errno == EINVAL);
+    assert(!auth_random_bytes(buf, -1) && errno == EINVAL);
+    assert(get_count == 0 && opens == 0 && weak_calls == 0);
+
+#ifdef auth_getrandom
+    reset();
+    get_results[0] = (struct result){ -1, EINTR };
+    get_results[1] = (struct result){ 3, 0 };
+    get_results[2] = (struct result){ 256, 0 };
+    get_results[3] = (struct result){ 41, 0 };
+    assert(auth_random_bytes(buf, sizeof(buf)));
+    expect_bytes(buf, sizeof(buf), 0xa5);
+    assert(get_count == 4 && opens == 0 && weak_calls == 0);
+#if defined(TEST_NO_RANDOM_H) && defined(__linux__) && defined(SYS_getrandom)
+    /* A libc symbol without its declaring header must not select the wrapper. */
+    assert(syscall_count == get_count);
+#endif
+
+    /* Keep the prefix from getrandom and fill only the remainder via the device. */
+    reset();
+    memset(buf, 0xcc, sizeof(buf));
+    get_results[0] = (struct result){ 3, 0 };
+    get_results[1] = (struct result){ -1, ENOSYS };
+    read_results[0] = (struct result){ 256, 0 };
+    read_results[1] = (struct result){ 41, 0 };
+    assert(auth_random_bytes(buf, sizeof(buf)));
+    expect_bytes(buf, 3, 0xa5);
+    expect_bytes(buf + 3, sizeof(buf) - 3, 0xb6);
+    assert(get_count == 2 && read_count == 2 && opens == 1 && closes == 1);
+    assert(weak_calls == 0 && warnings == 0 && errors == 0);
+
+    /* Even after partial success, EAGAIN must never reach /dev/urandom. */
+    reset();
+    get_results[0] = (struct result){ 3, 0 };
+    get_results[1] = (struct result){ -1, EAGAIN };
+    memset(buf, 0xcc, sizeof(buf));
+    assert(!auth_random_bytes(buf, sizeof(buf)) && errno == EAGAIN);
+    expect_bytes(buf, sizeof(buf), 0);
+    assert(opens == 0 && weak_calls == 0 && errors == 1);
+
+    /* Permission errors are not evidence that the API is absent. */
+    reset();
+    get_results[0] = (struct result){ -1, EPERM };
+    assert(!auth_random_bytes(buf, sizeof(buf)) && errno == EPERM);
+    assert(opens == 0 && weak_calls == 0);
+
+    reset();
+    assert(!auth_random_bytes(buf, sizeof(buf)) && errno == EIO);
+    assert(get_count == 1 && opens == 0);
+
+    /* Solaris also documents zero with errno set on failure. */
+    reset();
+    get_results[0] = (struct result){ 0, EAGAIN };
+    assert(!auth_random_bytes(buf, sizeof(buf)) && errno == EAGAIN);
+    assert(get_count == 1 && opens == 0);
+
+    reset();
+    allow_insecure_random = 1;
+    get_results[0] = (struct result){ 3, 0 };
+    get_results[1] = (struct result){ -1, EAGAIN };
+    assert(auth_random_bytes(buf, sizeof(buf)));
+    expect_bytes(buf, sizeof(buf), 0x5a);
+    assert(opens == 0 && weak_calls == 1 && warnings == 1);
+
+    /* Enabling the exception must not force use of the weak generator. */
+    reset();
+    allow_insecure_random = 1;
+    get_results[0] = (struct result){ 16, 0 };
+    assert(auth_random_bytes(buf, 16));
+    assert(weak_calls == 0 && warnings == 0);
+#endif
+
+    use_device();
+    open_eintr = 1;
+    read_results[0] = (struct result){ -1, EINTR };
+    read_results[1] = (struct result){ 3, 0 };
+    read_results[2] = (struct result){ 256, 0 };
+    read_results[3] = (struct result){ 41, 0 };
+    assert(auth_random_bytes(buf, sizeof(buf)));
+    expect_bytes(buf, sizeof(buf), 0xb6);
+    assert(opens == 2 && closes == 1 && read_count == 4 && weak_calls == 0);
+
+    use_device();
+    open_errno = ENOENT;
+    assert(!auth_random_bytes(buf, sizeof(buf)) && errno == ENOENT);
+    assert(closes == 0 && read_count == 0 && weak_calls == 0);
+
+    use_device();
+    open_errno = EACCES;
+    assert(!auth_random_bytes(buf, sizeof(buf)) && errno == EACCES);
+    assert(closes == 0 && weak_calls == 0);
+
+    use_device();
+    read_results[0] = (struct result){ 3, 0 };
+    read_results[1] = (struct result){ -1, EAGAIN };
+    assert(!auth_random_bytes(buf, sizeof(buf)) && errno == EAGAIN);
+    expect_bytes(buf, sizeof(buf), 0);
+    assert(closes == 1 && weak_calls == 0);
+
+    use_device();
+    read_results[0] = (struct result){ 3, 0 };
+    /* A zero-byte read must terminate, not spin or accept partial data. */
+    assert(!auth_random_bytes(buf, sizeof(buf)) && errno == EIO);
+    expect_bytes(buf, sizeof(buf), 0);
+    assert(closes == 1 && read_count == 2);
+
+    use_device();
+    open_errno = ENOENT;
+    allow_insecure_random = 1;
+    assert(auth_random_bytes(buf, sizeof(buf)));
+    expect_bytes(buf, sizeof(buf), 0x5a);
+    assert(weak_calls == 1 && warnings == 1 && errors == 0);
+
+    use_device();
+    allow_insecure_random = 1;
+    read_results[0] = (struct result){ 16, 0 };
+    assert(auth_random_bytes(buf, 16));
+    assert(weak_calls == 0 && warnings == 0);
+
+    puts("Authentication random-source tests passed");
+    return 0;
+}

--- a/pppd/chap-md5.c
+++ b/pppd/chap-md5.c
@@ -34,6 +34,7 @@
 #include "chap.h"
 #include "chap-md5.h"
 #include "magic.h"
+#include "auth-random.h"
 #include "crypto.h"
 
 #define MD5_MIN_CHALLENGE	16
@@ -46,8 +47,9 @@ chap_md5_generate_challenge(unsigned char *cp)
 
 	clen = (int)(drand48() * (MD5_MAX_CHALLENGE - MD5_MIN_CHALLENGE))
 		+ MD5_MIN_CHALLENGE;
-	*cp++ = clen;
-	random_bytes(cp, clen);
+	*cp = 0;
+	if (auth_random_bytes(cp + 1, clen))
+		*cp = clen;
 }
 
 static int

--- a/pppd/chap.c
+++ b/pppd/chap.c
@@ -121,7 +121,7 @@ static void chap_lowerup(int unit);
 static void chap_lowerdown(int unit);
 static void chap_server_timeout(void *arg);
 static void chap_client_timeout(void *arg);
-static void chap_generate_challenge(struct chap_server_state *ss);
+static int chap_generate_challenge(struct chap_server_state *ss);
 static void chap_handle_response(struct chap_server_state *ss, int code,
 		unsigned char *pkt, int len);
 static chap_verify_hook_fn chap_verify_response;
@@ -271,9 +271,16 @@ chap_server_timeout(void *arg)
 	struct chap_server_state *ss = arg;
 
 	ss->flags &= ~TIMEOUT_PENDING;
+	if (ss->flags & AUTH_FAILED)
+		return;
 	if ((ss->flags & CHALLENGE_VALID) == 0) {
 		ss->challenge_xmits = 0;
-		chap_generate_challenge(ss);
+		if (!chap_generate_challenge(ss)) {
+			error("CHAP: could not generate challenge");
+			ss->flags |= AUTH_DONE | AUTH_FAILED;
+			auth_peer_fail(0, PPP_CHAP);
+			return;
+		}
 		ss->flags |= CHALLENGE_VALID;
 	} else if (ss->challenge_xmits >= chap_max_transmits) {
 		ss->flags &= ~CHALLENGE_VALID;
@@ -304,7 +311,7 @@ chap_client_timeout(void *arg)
  * chap_generate_challenge - generate a challenge string and format
  * the challenge packet in ss->challenge_pkt.
  */
-static void
+static int
 chap_generate_challenge(struct chap_server_state *ss)
 {
 	size_t clen = 1, nlen, len;
@@ -313,8 +320,11 @@ chap_generate_challenge(struct chap_server_state *ss)
 	p = ss->challenge;
 	MAKEHEADER(p, PPP_CHAP);
 	p += CHAP_HDRLEN;
+	*p = 0;
 	ss->digest->generate_challenge(p);
 	clen = *p;
+	if (clen == 0)
+		return 0;
 	nlen = strlen(ss->name);
 	memcpy(p + 1 + clen, ss->name, nlen);
 
@@ -326,6 +336,7 @@ chap_generate_challenge(struct chap_server_state *ss)
 	p[1] = ++ss->id;
 	p[2] = len >> 8;
 	p[3] = len;
+	return 1;
 }
 
 /*
@@ -480,6 +491,8 @@ chap_respond(struct chap_client_state *cs, int id,
 
 	if ((cs->flags & (LOWERUP | AUTH_STARTED)) != (LOWERUP | AUTH_STARTED))
 		return;		/* not ready */
+	if (cs->flags & AUTH_FAILED)
+		return;
 	if (len < 2 || len < pkt[0] + 1)
 		return;		/* too short */
 	clen = pkt[0];
@@ -502,11 +515,20 @@ chap_respond(struct chap_client_state *cs, int id,
 	MAKEHEADER(p, PPP_CHAP);
 	p += CHAP_HDRLEN;
 
+	*p = 0;
 	cs->digest->make_response(p, id, cs->name, pkt,
 				  secret, secret_len, cs->priv);
 	memset(secret, 0, secret_len);
 
 	clen = *p;
+	if (clen == 0) {
+		error("CHAP: could not generate response");
+		UNTIMEOUT(chap_client_timeout, cs);
+		cs->flags &= ~TIMEOUT_PENDING;
+		cs->flags |= AUTH_DONE | AUTH_FAILED;
+		auth_withpeer_fail(0, PPP_CHAP);
+		return;
+	}
 	nlen = strlen(cs->name);
 	memcpy(p + clen + 1, cs->name, nlen);
 

--- a/pppd/chap.h
+++ b/pppd/chap.h
@@ -102,6 +102,7 @@ struct chap_digest_type {
 	/*
 	 * Note: challenge and response arguments below are formatted as
 	 * a length byte followed by the actual challenge/response data.
+	 * Generation callbacks must set the length to zero on failure.
 	 */
 	void (*generate_challenge)(unsigned char *challenge);
 	int (*verify_response)(int id, char *name,

--- a/pppd/chap_ms.c
+++ b/pppd/chap_ms.c
@@ -96,6 +96,7 @@
 #include "chap.h"
 #include "chap_ms.h"
 #include "magic.h"
+#include "auth-random.h"
 #include "mppe.h"
 #include "crypto.h"
 #include "crypto_ms.h"
@@ -161,25 +162,29 @@ static struct option chapms_option_list[] = {
 static void
 chapms_generate_challenge(unsigned char *challenge)
 {
-	*challenge++ = 8;
+	*challenge = 0;
 #ifdef DEBUGMPPEKEY
 	if (mschap_challenge && strlen(mschap_challenge) == 8)
-		memcpy(challenge, mschap_challenge, 8);
+		memcpy(challenge + 1, mschap_challenge, 8);
 	else
 #endif
-		random_bytes(challenge, 8);
+		if (!auth_random_bytes(challenge + 1, 8))
+			return;
+	*challenge = 8;
 }
 
 static void
 chapms2_generate_challenge(unsigned char *challenge)
 {
-	*challenge++ = 16;
+	*challenge = 0;
 #ifdef DEBUGMPPEKEY
 	if (mschap_challenge && strlen(mschap_challenge) == 16)
-		memcpy(challenge, mschap_challenge, 16);
+		memcpy(challenge + 1, mschap_challenge, 16);
 	else
 #endif
-		random_bytes(challenge, 16);
+		if (!auth_random_bytes(challenge + 1, 16))
+			return;
+	*challenge = 16;
 }
 
 static int
@@ -246,9 +251,10 @@ chapms2_verify_response(int id, char *name,
 		goto bad;	/* not even the right length */
 
 	/* Generate the expected response and our mutual auth. */
-	ChapMS2(challenge, &response[MS_CHAP2_PEER_CHALLENGE], name,
+	if (!ChapMS2(challenge, &response[MS_CHAP2_PEER_CHALLENGE], name,
 		(char *)secret, secret_len, md,
-		(unsigned char *)saresponse, MS_CHAP2_AUTHENTICATOR);
+		(unsigned char *)saresponse, MS_CHAP2_AUTHENTICATOR))
+		goto bad;
 
 	/* compare MDs and send the appropriate status */
 	/*
@@ -380,6 +386,7 @@ chapms2_make_response(unsigned char *response, int id, char *our_name,
 {
 	const struct chapms2_response_cache_entry *cache_entry;
 	unsigned char auth_response[MS_AUTH_RESPONSE_LENGTH+1];
+	unsigned char *lenp = response;
 
 	challenge++;	/* skip length, should be 16 */
 	*response++ = MS_CHAP2_RESPONSE_LEN;
@@ -388,14 +395,17 @@ chapms2_make_response(unsigned char *response, int id, char *our_name,
 		memcpy(response, cache_entry->response, MS_CHAP2_RESPONSE_LEN);
 		return;
 	}
-	ChapMS2(challenge,
+	if (!ChapMS2(challenge,
 #ifdef DEBUGMPPEKEY
 		mschap2_peer_challenge,
 #else
 		NULL,
 #endif
 		our_name, secret, secret_len, response, auth_response,
-		MS_CHAP2_AUTHENTICATEE);
+		MS_CHAP2_AUTHENTICATEE)) {
+		*lenp = 0;
+		return;
+	}
 	chapms2_add_to_response_cache(id, challenge, response, auth_response);
 }
 
@@ -830,26 +840,28 @@ ChapMS(u_char *rchallenge, char *secret, int secret_len,
  * If PeerChallenge is supplied, it is copied into the PeerChallenge field.
  * Call this way when verifying a response (or debugging).
  * Do not call with PeerChallenge = response.
+ * Returns 0 if generating a Peer-Challenge fails, otherwise 1.
  *
  * The PeerChallenge field of response is then used for calculation of the
  * Authenticator Response.
  */
-void
+int
 ChapMS2(unsigned char *rchallenge, unsigned char *PeerChallenge,
 	char *user, char *secret, int secret_len, unsigned char *response,
 	u_char authResponse[], int authenticator)
 {
     /* ARGSUSED */
     u_char *p = &response[MS_CHAP2_PEER_CHALLENGE];
-    int i;
 
     BZERO(response, MS_CHAP2_RESPONSE_LEN);
 
     /* Generate the Peer-Challenge if requested, or copy it if supplied. */
-    if (!PeerChallenge)
-	for (i = 0; i < MS_CHAP2_PEER_CHAL_LEN; i++)
-	    *p++ = (u_char) (drand48() * 0xff);
-    else
+    if (!PeerChallenge) {
+	if (!auth_random_bytes(p, MS_CHAP2_PEER_CHAL_LEN)) {
+	    BZERO(authResponse, MS_AUTH_RESPONSE_LENGTH + 1);
+	    return 0;
+	}
+    } else
 	BCOPY(PeerChallenge, &response[MS_CHAP2_PEER_CHALLENGE],
 	      MS_CHAP2_PEER_CHAL_LEN);
 
@@ -867,6 +879,7 @@ ChapMS2(unsigned char *rchallenge, unsigned char *PeerChallenge,
     SetMasterKeys(secret, secret_len,
 		  &response[MS_CHAP2_NTRESP], authenticator);
 #endif
+    return 1;
 }
 
 
@@ -904,13 +917,14 @@ int debug = 1;
 int error_count = 0;
 int unsuccess = 0;
 
-void random_bytes(unsigned char *bytes, int len)
+int auth_random_bytes(unsigned char *bytes, int len)
 {
     int i = 0;
     srand(time(NULL));
     while (i < len) {
         bytes[i++] = (unsigned char) rand();
     }
+    return 1;
 }
 
 

--- a/pppd/chap_ms.h
+++ b/pppd/chap_ms.h
@@ -77,7 +77,8 @@ extern "C" {
 #define MS_CHAP2_AUTHENTICATOR 1
 
 void ChapMS (u_char *, char *, int, u_char *);
-void ChapMS2 (u_char *, u_char *, char *, char *, int,
+/* Returns 0 if Peer-Challenge generation fails, otherwise 1. */
+int ChapMS2 (u_char *, u_char *, char *, char *, int,
 	      u_char *, u_char[MS_AUTH_RESPONSE_LENGTH+1], int);
 
 void ChallengeHash (u_char[16], u_char *, char *, u_char[8]);

--- a/pppd/eap.c
+++ b/pppd/eap.c
@@ -58,6 +58,7 @@
 #include <errno.h>
 
 #include "pppd-private.h"
+#include "auth-random.h"
 #include "options.h"
 #include "pathnames.h"
 #include "crypto.h"
@@ -184,6 +185,15 @@ eap_client_timeout(void *arg)
 	error("EAP: timeout waiting for Request from peer");
 	auth_withpeer_fail(esp->es_unit, PPP_EAP);
 	esp->es_client.ea_state = eapBadAuth;
+}
+
+/* A local generation failure must not negotiate another method or send data. */
+static void
+eap_client_fail(eap_state *esp)
+{
+	UNTIMEOUT(eap_client_timeout, esp);
+	esp->es_client.ea_state = eapBadAuth;
+	auth_withpeer_fail(esp->es_unit, PPP_EAP);
 }
 
 /*
@@ -468,7 +478,6 @@ eap_send_request(eap_state *esp)
 {
 	u_char *outp;
 	u_char *lenloc;
-	u_char *ptr;
 	int outlen;
 	int challen;
 	char *str;
@@ -528,9 +537,12 @@ eap_send_request(eap_state *esp)
 			    MIN_CHALLENGE_LENGTH;
 		PUTCHAR(challen, outp);
 		esp->es_challen = challen;
-		ptr = esp->es_challenge;
-		while (--challen >= 0)
-			*ptr++ = (u_char) (drand48() * 0x100);
+		if (!auth_random_bytes(esp->es_challenge, challen)) {
+			esp->es_challen = 0;
+			UNTIMEOUT(eap_server_timeout, esp);
+			eap_send_failure(esp);
+			return;
+		}
 		BCOPY(esp->es_challenge, outp, esp->es_challen);
 		INCPTR(esp->es_challen, outp);
 		BCOPY(esp->es_server.ea_name, outp, esp->es_server.ea_namelen);
@@ -539,9 +551,16 @@ eap_send_request(eap_state *esp)
 
 #ifdef PPP_WITH_CHAPMS
 	case eapMSCHAPv2Chall:
+		esp->es_challenge[0] = 0;
 		esp->es_server.digest->generate_challenge(esp->es_challenge);
 		challen = esp->es_challenge[0];
 		esp->es_challen = challen;
+		if (challen == 0) {
+			error("EAP: could not generate MS-CHAPv2 challenge");
+			UNTIMEOUT(eap_server_timeout, esp);
+			eap_send_failure(esp);
+			return;
+		}
 
 		PUTCHAR(EAPT_MSCHAPV2, outp);
 		PUTCHAR(CHAP_CHALLENGE, outp);
@@ -1288,9 +1307,15 @@ eap_request(eap_state *esp, u_char *inp, int id, int len)
 		esp->es_client.ea_namelen = strlen(esp->es_client.ea_name);
 
 		/* Create the MSCHAPv2 response (and add to cache) */
-		unsigned char response[MS_CHAP2_RESPONSE_LEN+1]; // VLEN + VALUE
+		unsigned char response[MS_CHAP2_RESPONSE_LEN+1] = { 0 }; // VLEN + VALUE
 		esp->es_client.digest->make_response(response, chapid, esp->es_client.ea_name,
 			challenge, secret, secret_len, NULL);
+		ppp_explicit_bzero(secret, secret_len);
+		if (response[0] == 0) {
+			error("EAP: could not generate MS-CHAPv2 response");
+			eap_client_fail(esp);
+			return;
+		}
 
 		eap_chapv2_response(esp, id, chapid, response, esp->es_client.ea_name, esp->es_client.ea_namelen);
 		esp->es_client.ea_state = eapAuthRecv;
@@ -1330,7 +1355,8 @@ eap_request(eap_state *esp, u_char *inp, int id, int len)
 	    break;
 #endif /* PPP_WITH_CHAPMS */
 #ifdef PPP_WITH_PEAP
-	case EAPT_PEAP:
+	case EAPT_PEAP: {
+		int result;
 
 		/* Initialize the PEAP context (if not already initialized) */
 		if (!esp->ea_peap) {
@@ -1345,7 +1371,13 @@ eap_request(eap_state *esp, u_char *inp, int id, int len)
 		}
 
 		/* Process the PEAP packet */
-		if (peap_process(esp, id, inp, len)) {
+		result = peap_process(esp, id, inp, len);
+		if (result == PEAP_AUTH_FAILED) {
+			peap_finish(&esp->ea_peap);
+			eap_client_fail(esp);
+			return;
+		}
+		if (result) {
 			if (esp->es_client.ea_state = eapListen)
 				eap_send_nak(esp, id, EAPT_TLS);
 			else {
@@ -1358,6 +1390,7 @@ eap_request(eap_state *esp, u_char *inp, int id, int len)
 			esp->es_client.ea_state = eapAuthRecv;
 
 		break;
+	}
 #endif // PPP_WITH_PEAP
 
 	default:

--- a/pppd/peap.c
+++ b/pppd/peap.c
@@ -418,12 +418,18 @@ void peap_do_inner_eap(u_char *in_buf, int in_len, eap_state *esp, int id,
 			if (get_secret(esp->es_unit, esp->es_client.ea_name,
 						rhostname, secret, &secret_len, 0)) {
 
-				u_char response[MS_CHAP2_RESPONSE_LEN+1];
+				u_char response[MS_CHAP2_RESPONSE_LEN+1] = { 0 };
 				u_char user_len = esp->es_client.ea_namelen;
 				char *user = esp->es_client.ea_name;
 
 				psm->chap->make_response(response, chap_id, user,
 						challenge, secret, secret_len, NULL);
+				ppp_explicit_bzero(secret, secret_len);
+				if (response[0] == 0) {
+					error("PEAP: could not generate MS-CHAPv2 response");
+					*out_len = -1;
+					return;
+				}
 
 				PUTCHAR(EAPT_MSCHAPV2, outp);
 				PUTCHAR(CHAP_RESPONSE, outp);
@@ -647,6 +653,8 @@ int peap_process(eap_state *esp, u_char id, u_char *inp, int len)
 		out_len = TLS_RECORD_MAX_SIZE;
 		peap_do_inner_eap(psm->in_buf, psm->read, esp, id,
 				psm->out_buf, &out_len);
+		if (out_len < 0)
+			return PEAP_AUTH_FAILED;
 		if (out_len > 0) {
 			psm->written = SSL_write(psm->ssl, psm->out_buf, out_len);
 			psm->read = BIO_read(psm->out_bio, psm->out_buf,

--- a/pppd/peap.h
+++ b/pppd/peap.h
@@ -82,6 +82,9 @@
 
 struct peap_state;
 
+/* Local authentication failure; do not negotiate another EAP method. */
+#define PEAP_AUTH_FAILED (-2)
+
 /**
  * Initialize the PEAP structure
  */

--- a/pppd/pppd.8
+++ b/pppd/pppd.8
@@ -232,6 +232,22 @@ Note that it
 is possible to apply different constraints to incoming and outgoing
 packets using the \fBinbound\fR and \fBoutbound\fR qualifiers.
 .TP
+.B allow\-insecure\-random
+Allow authentication challenges to use the legacy, predictable random number
+generator if the operating system random source fails.  This privileged option
+is disabled by default and should only be used on trusted transports.  A warning
+is logged whenever the fallback is used.  It does not affect TLS randomness.
+.IP
+By default, CHAP and EAP authentication challenges use operating system
+cryptographic randomness, with or without OpenSSL support.  Where available,
+getrandom with GRND_NONBLOCK is used; an uninitialized source fails the current
+authentication attempt without waiting or falling back to /dev/urandom.
+When that interface is unavailable, /dev/urandom is used instead.  On older
+Linux systems this device can return data before RNG initialization is complete;
+the compatibility fallback does not detect this early-boot condition.
+If random bytes cannot be obtained, the authentication attempt fails unless
+allow-insecure-random is enabled.
+.TP
 .B allow\-ip \fIaddress(es)
 Allow peers to use the given IP address or subnet without
 authenticating themselves.  The parameter is parsed as for each


### PR DESCRIPTION
Closes #616.

`random_bytes()` and the direct `drand48()` calls that produce CHAP, EAP-MD5 and MS-CHAPv2 challenge material all draw on the same 48-bit `rand48` state that `magic()` uses for LCP Magic-Numbers. Since the Magic-Numbers are sent to the peer before authentication, an active peer is handed outputs of the same generator state that will later produce the authentication challenge. 

This series adds a separate OS-backed source for authentication challenge contents and leaves the existing PRNG in place for everything that does not need cryptographic unpredictability.

## What changes

New `auth_random_bytes()` in `pppd/auth-random.c`:

* `getrandom()` with `GRND_NONBLOCK` where available. On Linux the raw syscall is used when libc has no wrapper, so older glibc still gets the kernel interface;
* `EAGAIN` (pool not yet initialised) fails the current authentication attempt. It does **not** fall through to `/dev/urandom`, which would defeat the point;
* `/dev/urandom` is used only when the interface is absent (`ENOSYS`), opened `O_NONBLOCK | O_CLOEXEC`, with full short-read and `EINTR` handling;
* On failure the output buffer is zeroed, so a partial OS result can never reach the wire;
* Nothing in this path can block, at any point.

Call sites converted: CHAP-MD5 challenge, MS-CHAP and MS-CHAPv2 authenticator challenges, EAP-MD5 challenge contents, MS-CHAPv2 Peer-Challenge.

Left on the existing PRNG, deliberately: LCP Magic-Numbers, CHAP and EAP packet identifiers, and randomised challenge lengths.

Failures are propagated through CHAP, EAP and PEAP so that no challenge or response is transmitted and no failed MS-CHAPv2 response is added to the response cache. Without the cache guard, a retransmission of the same challenge
would resend an all-zero response from cache without consulting the RNG again.

## Policy: fail closed, with a privileged opt-out

By default a failure to obtain secure randomness fails the authentication attempt. The new privileged `allow-insecure-random` option lets an administrator accept the legacy PRNG instead, with a warning logged each time the fallback is used. It is `OPT_PRIV`, so it cannot be set from a per-peer entry in a secrets file; a remote peer cannot request or negotiate the
fallback. There is a unit test for exactly that vector.

The option and the early-boot caveat for `/dev/urandom` on older Linux kernels are documented in `pppd.8`.

## Why not `RAND_bytes()`

It was suggested in the issue thread, and I ended up not using it:

* It does not address the concern that prompted the non-blocking design. OpenSSL 3.x seeds from `getrandom()` without `GRND_NONBLOCK` by default, so `RAND_bytes()` can block until the kernel pool is initialised — which is the
  early-boot hang scenario raised in the thread;
* Builds without OpenSSL would need the OS path regardless, so using `RAND_bytes()` would mean maintaining two implementations with different failure and blocking semantics.

Using the OS interface directly in both build configurations gives one code path with one set of semantics. Happy to revisit if you would rather have `RAND_bytes()` where OpenSSL is present.

## Why not `arc4random_buf()`

It has no recoverable error return and no non-blocking flag. On FreeBSD 12 and later it is backed by `getrandom()` and blocks until the pool is seeded, so it cannot implement either half of the policy above. The rationale is recorded in a comment in `auth-random.c`.

## API note

`ChapMS2()` changes from `void` to `int` so it can report a Peer-Challenge generation failure, and `chap_ms.h` is an installed header. In practice this is a source-level change only: callers that ignore the new return value are unaffected, and on common ABIs an already-compiled plugin keeps working. It still deserves a mention in the release notes.

The `struct chap_digest_type` plugin interface is **not** changed. `chap.c` zeroes the length byte before invoking generate_challenge` / `make_response`, so an out-of-tree digest that simply writes the length behaves exactly as before; the zero length is the failure signal.

`peap_process()` gains `PEAP_AUTH_FAILED` (-2), distinct from its existing -1, so a local randomness failure does not land in the branch that NAKs to `EAPT_TLS`. A local failure must not trigger a method downgrade.

## Behaviour note

If challenge generation fails during a CHAP re-challenge on an already established link, the link is torn down rather than retried. With `GRND_NONBLOCK` this is essentially unreachable after boot, since the CRNG stays initialised; the realistic failure mode is the `/dev/urandom` path under descriptor exhaustion. Say the word if you would prefer a retry bounded by `chap-max-challenge` instead.

## Tests

Six new `check_PROGRAMS`:

* `utest_auth_random`, `utest_auth_random_device`, `utest_auth_random_syscall`, `utest_auth_random_no_header` — the real selection code compiled against scripted `getrandom`/`syscall`/`open`/`read` results, covering `EINTR`, `EAGAIN`, `ENOSYS`, permission errors, short reads, EOF, partial fills that continue into the device, and the privileged fallback. The four variants exercise the libc wrapper, the raw Linux syscall, device-only operation, and the case where the libc symbol exists without its declaring header;
* `utest_auth_protocol` — CHAP, EAP and PEAP state machines driven with failing randomness, asserting that nothing is sent or cached, plus the success and retransmission paths;
* `utest_auth_options` — the real option parser, asserting that an unprivileged source cannot enable the opt-out.

## Not covered

* Tested on Linux only. Solaris picks up `getrandom(2)` from `<sys/random.h>` on 11.3 and later and otherwise falls back to `/dev/urandom`, but I have no Solaris system to confirm this on;
* Early-boot behaviour on a real system has not been exercised.

Per the discussion in #616 this is not proposed for 2.5.4.

## Noticed but left alone

Two pre-existing issues adjacent to the code touched here, not addressed in this series:

* `pppd/eap.c`, PEAP request handling: `if (esp->es_client.ea_state = eapListen)` is an assignment, not a comparison. The branch is reachable, since `peap_process()` returns -1 on retransmit and on handshake errors.
* `peap_finish()` does not free `psm->in_buf` / `psm->out_buf`, which `peap_init()` allocates.

Happy to send either as a separate patch.